### PR TITLE
[portfolio] Halve the mobile page height with interaction, not deletion

### DIFF
--- a/scripts/lib/audit.mjs
+++ b/scripts/lib/audit.mjs
@@ -1,0 +1,88 @@
+/**
+ * The audit walks, shared.
+ *
+ * These run inside the page rather than in node, so they are source strings
+ * handed to `page.evaluate` rather than functions. They live here because
+ * verify is no longer the only thing that needs them: a mobile round that has
+ * to clear AA after every unit cannot afford a five-minute pass to find out,
+ * and two copies of a contrast formula is one copy too many.
+ */
+
+/* Relative luminance and the WCAG ratio, so the palette is checked rather than
+   asserted. A dawn light on slate is not automatically safe. */
+export const CONTRAST = `(() => {
+  const lin = (c) => (c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4));
+  const lum = ([r, g, b]) => 0.2126 * lin(r / 255) + 0.7152 * lin(g / 255) + 0.0722 * lin(b / 255);
+  const parse = (s) => (s.match(/[\\d.]+/g) ?? []).slice(0, 4).map(Number);
+  const over = (fg, bg) => {
+    const a = fg.length > 3 ? fg[3] : 1;
+    return [0, 1, 2].map((i) => fg[i] * a + bg[i] * (1 - a));
+  };
+  const opaque = (c) => (c.length > 3 ? c[3] > 0.92 : c.length === 3);
+  // An ancestor walk cannot see a layer that is not an ancestor. The selected
+  // tab's sand pill is an absolutely positioned sibling painted underneath it,
+  // so walking up from the label finds the dark card and reports ink on ink.
+  const beneath = (el) => {
+    const r = el.getBoundingClientRect();
+    for (let n = el.parentElement; n; n = n.parentElement) {
+      for (const sib of n.children) {
+        if (sib === el || sib.contains(el)) continue;
+        const cs = getComputedStyle(sib);
+        if (cs.position !== 'absolute' && cs.position !== 'fixed') continue;
+        const c = parse(cs.backgroundColor);
+        if (!opaque(c)) continue;
+        const s = sib.getBoundingClientRect();
+        if (s.left <= r.left + 1 && s.right >= r.right - 1 && s.top <= r.top + 1 && s.bottom >= r.bottom - 1)
+          return c.slice(0, 3);
+      }
+    }
+    return null;
+  };
+  const ground = (el) => {
+    const layer = beneath(el);
+    if (layer) return layer;
+    for (let n = el; n; n = n.parentElement) {
+      const c = parse(getComputedStyle(n).backgroundColor);
+      if (opaque(c)) return c.slice(0, 3);
+    }
+    return [255, 255, 255];
+  };
+  const out = [];
+  const seen = new Set();
+  for (const el of document.querySelectorAll('body *')) {
+    const text = [...el.childNodes].some((n) => n.nodeType === 3 && n.textContent.trim());
+    if (!text) continue;
+    const cs = getComputedStyle(el);
+    if (cs.visibility === 'hidden' || cs.display === 'none' || cs.opacity === '0') continue;
+    const r = el.getBoundingClientRect();
+    if (!r.width || !r.height) continue;
+    const bg = ground(el);
+    // Transparent fill with a stroke is drawn type, not invisible type: the
+    // outlined second name line is painted entirely by -webkit-text-stroke, so
+    // that is the colour a reader sees and the colour worth measuring.
+    let col = parse(cs.color);
+    const strokeW = parseFloat(cs.webkitTextStrokeWidth) || 0;
+    if ((col.length > 3 ? col[3] : 1) === 0) {
+      if (strokeW <= 0) continue;
+      col = parse(cs.webkitTextStrokeColor);
+    }
+    const fg = over(col, bg);
+    const key = col.join(',') + '|' + bg.join(',');
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const l1 = lum(fg);
+    const l2 = lum(bg);
+    const ratio = (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05);
+    const px = parseFloat(cs.fontSize);
+    const bold = parseInt(cs.fontWeight, 10) >= 700;
+    const large = px >= 24 || (bold && px >= 18.66);
+    out.push({
+      sel: el.tagName.toLowerCase() + '.' + String(el.className).trim().split(/\\s+/)[0],
+      ratio: Math.round(ratio * 100) / 100,
+      need: large ? 3 : 4.5,
+      fg: 'rgb(' + fg.map(Math.round).join(', ') + ')',
+      bg: 'rgb(' + bg.map(Math.round).join(', ') + ')',
+    });
+  }
+  return out.filter((r) => r.ratio < r.need);
+})()`;

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -11,6 +11,7 @@
 import { chromium } from 'playwright';
 import sharp from 'sharp';
 import { mkdir, readFile } from 'node:fs/promises';
+import { CONTRAST } from './lib/audit.mjs';
 
 const BASE = process.argv[2] ?? 'http://127.0.0.1:4321/';
 const OUT = process.argv[3] ?? '/tmp/p6shots';
@@ -78,86 +79,7 @@ async function run(name, opts, body, url = BASE) {
   await browser.close();
 }
 
-/* Relative luminance and the WCAG ratio, so the palette is checked rather than
-   asserted. A dawn light on slate is not automatically safe. */
-const CONTRAST = `(() => {
-  const lin = (c) => (c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4));
-  const lum = ([r, g, b]) => 0.2126 * lin(r / 255) + 0.7152 * lin(g / 255) + 0.0722 * lin(b / 255);
-  const parse = (s) => (s.match(/[\\d.]+/g) ?? []).slice(0, 4).map(Number);
-  const over = (fg, bg) => {
-    const a = fg.length > 3 ? fg[3] : 1;
-    return [0, 1, 2].map((i) => fg[i] * a + bg[i] * (1 - a));
-  };
-  const opaque = (c) => (c.length > 3 ? c[3] > 0.92 : c.length === 3);
-  // An ancestor walk cannot see a layer that is not an ancestor. The selected
-  // tab's sand pill is an absolutely positioned sibling painted underneath it,
-  // so walking up from the label finds the dark card and reports ink on ink.
-  const beneath = (el) => {
-    const r = el.getBoundingClientRect();
-    for (let n = el.parentElement; n; n = n.parentElement) {
-      for (const sib of n.children) {
-        if (sib === el || sib.contains(el)) continue;
-        const cs = getComputedStyle(sib);
-        if (cs.position !== 'absolute' && cs.position !== 'fixed') continue;
-        const c = parse(cs.backgroundColor);
-        if (!opaque(c)) continue;
-        const s = sib.getBoundingClientRect();
-        if (s.left <= r.left + 1 && s.right >= r.right - 1 && s.top <= r.top + 1 && s.bottom >= r.bottom - 1)
-          return c.slice(0, 3);
-      }
-    }
-    return null;
-  };
-  const ground = (el) => {
-    const layer = beneath(el);
-    if (layer) return layer;
-    for (let n = el; n; n = n.parentElement) {
-      const c = parse(getComputedStyle(n).backgroundColor);
-      if (opaque(c)) return c.slice(0, 3);
-    }
-    return [255, 255, 255];
-  };
-  const out = [];
-  const seen = new Set();
-  for (const el of document.querySelectorAll('body *')) {
-    const text = [...el.childNodes].some((n) => n.nodeType === 3 && n.textContent.trim());
-    if (!text) continue;
-    const cs = getComputedStyle(el);
-    if (cs.visibility === 'hidden' || cs.display === 'none' || cs.opacity === '0') continue;
-    const r = el.getBoundingClientRect();
-    if (!r.width || !r.height) continue;
-    const bg = ground(el);
-    // Transparent fill with a stroke is drawn type, not invisible type: the
-    // outlined second name line is painted entirely by -webkit-text-stroke, so
-    // that is the colour a reader sees and the colour worth measuring.
-    let col = parse(cs.color);
-    const strokeW = parseFloat(cs.webkitTextStrokeWidth) || 0;
-    if ((col.length > 3 ? col[3] : 1) === 0) {
-      if (strokeW <= 0) continue;
-      col = parse(cs.webkitTextStrokeColor);
-    }
-    const fg = over(col, bg);
-    const key = col.join(',') + '|' + bg.join(',');
-    if (seen.has(key)) continue;
-    seen.add(key);
-    const l1 = lum(fg);
-    const l2 = lum(bg);
-    const ratio = (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05);
-    const px = parseFloat(cs.fontSize);
-    const bold = parseInt(cs.fontWeight, 10) >= 700;
-    const large = px >= 24 || (bold && px >= 18.66);
-    out.push({
-      sel: el.tagName.toLowerCase() + '.' + String(el.className).trim().split(/\\s+/)[0],
-      ratio: Math.round(ratio * 100) / 100,
-      need: large ? 3 : 4.5,
-      fg: 'rgb(' + fg.map(Math.round).join(', ') + ')',
-      bg: 'rgb(' + bg.map(Math.round).join(', ') + ')',
-    });
-  }
-  return out.filter((r) => r.ratio < r.need);
-})()`;
-
-/* The walk above cannot check the hero, and quietly reports it as passing.
+/* The shared walk cannot check the hero, and quietly reports it as passing.
    Every ancestor of the hero's type is transparent down to a canvas, so a
    computed-style ground is the page colour rather than the drifting light that
    is actually behind the letters. The only honest ground there is the pixel

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -23,6 +23,11 @@ const OUT = process.argv[3] ?? '/tmp/p6shots';
    quietly growing a section back does. */
 const HEIGHT_BUDGET = 13000;
 
+/* The same number for the phone, which used to be twice it. 12,708px after the
+   swipe rows, the ledger and the card fold; the margin is one folded card, on
+   the same reasoning as the line above. */
+const MOBILE_BUDGET = 13200;
+
 const fail = [];
 const note = (ok, label, detail) => {
   if (!ok) fail.push(`${label}: ${detail}`);
@@ -777,6 +782,93 @@ await run(
       `${m.mail.w} of ${m.mail.rowW}`,
     );
     note(m.tap.length === 0, '390 every control clears a 34px tap target', m.tap.join(', '));
+
+    /* The three mechanisms this width is built out of, each checked where it
+       can actually be wrong: a set that does not scroll, a ledger that shipped
+       already open, a fold that swallowed the text it was meant to hold. */
+    const mob = await page.evaluate(() => {
+      const vw = document.documentElement.clientWidth;
+      const rows = [...document.querySelectorAll('.swipe__row')];
+      const folds = [...document.querySelectorAll('.tl .fold')];
+      const deeps = [...document.querySelectorAll('.deep')];
+      const held = document.activeElement;
+      const reach = rows.every((r) => {
+        r.focus();
+        return (
+          document.activeElement === r ||
+          r.contains(document.activeElement) ||
+          !!r.querySelector('a[href], button')
+        );
+      });
+      if (held instanceof HTMLElement) held.focus();
+      return {
+        rows: rows.length,
+        scrolls: rows.filter((r) => r.scrollWidth > r.clientWidth + 2).length,
+        snaps: rows.filter((r) => getComputedStyle(r).scrollSnapType === 'x mandatory').length,
+        peek: rows.every((r) =>
+          [...r.children].every((c) => {
+            const w = c.getBoundingClientRect().width;
+            return w > vw * 0.7 && w < vw * 0.86;
+          }),
+        ),
+        reach,
+        ledger: folds.length,
+        shut: folds.every((d) => !d.open),
+        kept: folds.every((d) => !!d.querySelector(':scope > div > *')),
+        deeps: deeps.length,
+        untilFound: deeps.every((d) => d.getAttribute('hidden') === 'until-found'),
+        /* content-visibility, not display: none. The difference is whether
+           find-in-page can reach the four cards' whole argument. */
+        reachable: deeps.every((d) => getComputedStyle(d).contentVisibility === 'hidden'),
+      };
+    });
+
+    /* One row, because it was the only set left stacked: the arc, the region
+       switcher and the deviation card each carry a horizontal grammar of their
+       own, and the pattern was lifted out of the last of them. */
+    note(
+      mob.rows === 1 && mob.scrolls === 1 && mob.snaps === 1,
+      '390 the stacked set is a snapping swipe row',
+      `${mob.rows} rows, ${mob.scrolls} scroll, ${mob.snaps} snap`,
+    );
+    note(mob.peek, '390 a swipe card is ~78vw, so the next one peeks', '');
+    note(mob.reach, '390 a swipe row is reachable without a thumb', '');
+    note(
+      mob.ledger === 7 && mob.shut && mob.kept,
+      '390 the finished jobs are a shut ledger with their entries still in it',
+      `${mob.ledger} rows, all shut ${mob.shut}, entries kept ${mob.kept}`,
+    );
+    note(
+      mob.deeps === 4 && mob.untilFound && mob.reachable,
+      '390 each project folds to hidden="until-found", not out of the document',
+      `${mob.deeps} folds, until-found ${mob.untilFound}, findable ${mob.reachable}`,
+    );
+
+    /* One press, opened, because everything above is true of a fold that does
+       not open either. */
+    const opened = await page.evaluate(async () => {
+      const card = document.getElementById('p-elderwood');
+      card.querySelector('.deep__go').click();
+      await new Promise((r) => setTimeout(r, 200));
+      const deep = card.querySelector('.deep');
+      return {
+        shown: !deep.hasAttribute('hidden'),
+        gone: getComputedStyle(card.querySelector('.deep__go')).display === 'none',
+        focus: document.activeElement?.className,
+        rest: document.querySelectorAll('.card[data-fold]').length,
+      };
+    });
+    note(
+      opened.shown && opened.gone && opened.focus === 'deep' && opened.rest === 3,
+      '390 the press opens its own card and hands over the focus it held',
+      `shown ${opened.shown}, press gone ${opened.gone}, focus ${opened.focus}, ${opened.rest} still shut`,
+    );
+
+    note(
+      m.height <= MOBILE_BUDGET,
+      `390 page fits the ${MOBILE_BUDGET}px budget`,
+      `measured ${m.height}px`,
+    );
     console.log(`       page height ${m.height}px at 390`);
 
     /* The narrow hero stacks the type lower into the frame, past where the

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -44,7 +44,14 @@ async function settle(page) {
     }
     window.scrollTo({ top: 0, behavior: 'instant' });
     await Promise.all(
-      [...document.images].filter((i) => !i.complete).map((i) => i.decode().catch(() => {})),
+      [...document.images]
+        .filter((i) => !i.complete)
+        /* A lazy image inside a folded card is not being rendered, so it is not
+           being fetched either, and its decode never settles rather than
+           failing. Waiting on that forever is how a pass hangs at 390. */
+        .map((i) =>
+          Promise.race([i.decode().catch(() => {}), new Promise((r) => setTimeout(r, 2000))]),
+        ),
     );
     await document.fonts.ready;
   });
@@ -229,8 +236,9 @@ await run(
           const r = e.getBoundingClientRect();
           if (!(r.width > 0) || getComputedStyle(e).position === 'fixed') return false;
           // Wider than the viewport on purpose, under its own overflow: the
-          // frame switcher, and the 2015 file at a size it will not bend.
-          if (e.closest('.fs__scroll, .devframe, .asm__loupe')) return false;
+          // frame switcher, the swipe row, and the 2015 file at a size it will
+          // not bend.
+          if (e.closest('.fs__scroll, .swipe__row, .devframe, .asm__loupe')) return false;
           return r.right > de.clientWidth + 1;
         })
         .map((e) => `${e.tagName}.${e.className}`.slice(0, 40));
@@ -672,8 +680,9 @@ await run(
           const r = e.getBoundingClientRect();
           if (!(r.width > 0) || getComputedStyle(e).position === 'fixed') return false;
           // Wider than the viewport on purpose, under its own overflow: the
-          // frame switcher, and the 2015 file at a size it will not bend.
-          if (e.closest('.fs__scroll, .devframe, .asm__loupe')) return false;
+          // frame switcher, the swipe row, and the 2015 file at a size it will
+          // not bend.
+          if (e.closest('.fs__scroll, .swipe__row, .devframe, .asm__loupe')) return false;
           return r.right > de.clientWidth + 1;
         })
         .map((e) => `${e.tagName}.${e.className}`.slice(0, 40));
@@ -1046,7 +1055,7 @@ await run(
                and are clipped to it; a rect is the wrong instrument for them,
                because getBoundingClientRect reports geometry the reader never
                sees. Everything else on the page still has to fit. */
-            if (e.closest('.fs__scroll, .devframe, .asm__loupe')) return false;
+            if (e.closest('.fs__scroll, .swipe__row, .devframe, .asm__loupe')) return false;
             return r.right > de.clientWidth + 1;
           })
           .map((e) => `${e.tagName}.${e.className}`.slice(0, 40));

--- a/src/components/Deep.astro
+++ b/src/components/Deep.astro
@@ -1,0 +1,39 @@
+---
+/**
+ * The part of a project card a phone has to ask for.
+ *
+ * Four cards carry their whole argument inline: the prose, the interactive
+ * figure, the proof panel and the technical notes. On a wide screen that is
+ * the point of them. At 390 it is 7,400px of Projects, and a reader who wants
+ * the fourth card scrolls past three arguments to reach its name.
+ *
+ * So below 620 everything under the skim folds behind one press, and the card
+ * on a phone is what a phone can hold: the frame, the name, the numbers and a
+ * way in. Nothing is removed. The whole card is in the served markup, and the
+ * fold is `hidden="until-found"`, so find-in-page opens it, a fragment link
+ * opens it, and a crawler never sees it shut.
+ *
+ * The wrapper is `display: contents` above the breakpoint, so the wide layout
+ * gets exactly the boxes it had. The attribute that folds it is written by the
+ * script rather than served, for the same two reasons as the work log's
+ * ledger: a fold in the markup is one a desktop reader could meet, and a
+ * scriptless phone should get the card whole rather than a press that cannot
+ * answer.
+ */
+interface Props {
+  /** What opens, named. A press that says "more" is a press nobody makes. */
+  label: string;
+}
+
+const { label } = Astro.props;
+---
+
+{
+  /* Same pill, same chevron as the technical notes it usually sits above. The
+    fold is the same offer one size up, so it should not look like a new one. */
+}
+<button class="deep__go" type="button" data-deep-go>{label}</button>
+
+<div class="deep" data-deep>
+  <slot />
+</div>

--- a/src/components/react/AutoTyper.tsx
+++ b/src/components/react/AutoTyper.tsx
@@ -175,7 +175,7 @@ export default function AutoTyper() {
             than left to the re-render, because `type` reads it in the same tick
             and would otherwise skip the very run being asked for. */}
         <button
-          className="choice choice--go typer__go"
+          className="choice typer__go"
           type="button"
           onClick={() => {
             asked.current = true;

--- a/src/components/react/AutoTyper.tsx
+++ b/src/components/react/AutoTyper.tsx
@@ -36,6 +36,11 @@ const START_MS = 25;
    finishes inside half a minute. */
 const LIMIT = 140;
 
+/* Where the two controls stop being worth 191px of a phone. Below it the card
+   opens as its own finished output and one press, and the field, the slider and
+   the presets arrive when a thumb asks for them. */
+const NARROW = '(width <= 620px)';
+
 export default function AutoTyper() {
   const [source, setSource] = useState(PRESETS[0]?.[1] ?? '');
   const [preset, setPreset] = useState(0);
@@ -56,6 +61,17 @@ export default function AutoTyper() {
      does not disturb a finished run until you ask for one. */
   const running = useRef(PRESETS[0]?.[1] ?? '');
   const uid = useId();
+  /* Folded is a state the script arrives at, not one the markup ships in. The
+     island is server-rendered, and with no script a card whose controls are
+     hidden behind a press that cannot answer is worse than a card whose
+     controls are merely inert. So the attribute is written on mount, which is
+     the same moment the press starts working.
+     Unasked, the run is skipped rather than hidden - forty timers writing a
+     line into a box the reader has not opened is the work without the demo. */
+  const [fold, setFold] = useState(false);
+  const narrow = useRef(false);
+  const asked = useRef(false);
+  const goRef = useRef<HTMLButtonElement>(null);
 
   const type = useCallback((phrase: string) => {
     running.current = phrase;
@@ -63,7 +79,12 @@ export default function AutoTyper() {
     window.clearTimeout(timer.current);
     setSaid('');
 
-    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches || !visible.current) {
+    const still = narrow.current && !asked.current;
+    if (
+      still ||
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches ||
+      !visible.current
+    ) {
       setText(phrase);
       setSaid(phrase);
       return;
@@ -80,6 +101,20 @@ export default function AutoTyper() {
       else setSaid(phrase);
     };
     step();
+  }, []);
+
+  /* Read before the observer below asks for a run, and kept current, because a
+     phone turned on its side crosses this and the run it is about to start
+     should be the one the new width wants. */
+  useEffect(() => {
+    const mq = window.matchMedia(NARROW);
+    const read = (): void => {
+      narrow.current = mq.matches;
+      setFold(mq.matches && !asked.current);
+    };
+    read();
+    mq.addEventListener('change', read);
+    return () => mq.removeEventListener('change', read);
   }, []);
 
   // Nothing types until the panel is on screen, and scrolling away mid-phrase
@@ -107,11 +142,20 @@ export default function AutoTyper() {
     };
   }, [type]);
 
+  /* The press that opened the card is gone by the time the controls are drawn,
+     so focus would land on the body and the next tab would start at the top of
+     the page. It goes to the run button, which is the same press again. Only
+     after a press: unfolding by rotating the phone is not a press, and the
+     first paint is not one either. */
+  useEffect(() => {
+    if (!fold && asked.current) goRef.current?.focus();
+  }, [fold]);
+
   const phrase = source.trim();
 
   return (
     <>
-      <div className="stage stage--typer">
+      <div className="stage stage--typer" data-fold={fold || undefined}>
         <span className="stage__label">Live output</span>
         <p className="term">
           <span className="term__p" aria-hidden="true">
@@ -125,6 +169,22 @@ export default function AutoTyper() {
         <p className="sr" aria-live="polite">
           {said}
         </p>
+
+        {/* In the document at every width and drawn at none of them until the
+            card says it is folded. `asked` is written before the run rather
+            than left to the re-render, because `type` reads it in the same tick
+            and would otherwise skip the very run being asked for. */}
+        <button
+          className="choice choice--go typer__go"
+          type="button"
+          onClick={() => {
+            asked.current = true;
+            setFold(false);
+            type(running.current);
+          }}
+        >
+          Try it
+        </button>
 
         <form
           className="typer"
@@ -151,7 +211,7 @@ export default function AutoTyper() {
                 setPreset(-1);
               }}
             />
-            <button className="choice choice--go" type="submit" disabled={!phrase}>
+            <button className="choice choice--go" type="submit" disabled={!phrase} ref={goRef}>
               Type it
             </button>
           </div>

--- a/src/components/react/DeviationFrame.tsx
+++ b/src/components/react/DeviationFrame.tsx
@@ -41,6 +41,13 @@ const H = 595;
     card above the 665px that costs, so this only ever bites on a phone. */
 const MIN = 0.5;
 
+/** Where the shrinking stops and the sideways scroll would start - the same
+    crossing the stylesheet knows. Below it the poster is the better chart: it
+    is the same seed drawn whole at the card's width rather than half of one at
+    half scale, and it does not pull Chart.js off a CDN to sample two thousand
+    deviates on a handset. So down here the file waits to be asked. */
+const HANDSET = '(width <= 765px)';
+
 export default function DeviationFrame({ src, href, title, poster, posterAlt, note }: Props) {
   const [live, setLive] = useState(false);
   const [scale, setScale] = useState(MIN);
@@ -52,6 +59,25 @@ export default function DeviationFrame({ src, href, title, poster, posterAlt, no
   const returnTo = useRef<HTMLElement | null>(null);
   /** Lets the frame's own load end the hold below, from outside this effect. */
   const unpin = useRef<(() => void) | null>(null);
+  /** True where the reader has to ask. Read rather than rendered: branching the
+      markup on a media query is a hydration mismatch, and the press below is in
+      the document at every width with the stylesheet deciding where it shows. */
+  const handset = useRef(false);
+  /** The boot, lent out to that press. It is defined inside the effect below
+      because the scroll hold it opens with has to go up in the same instant. */
+  const ask = useRef<(() => void) | null>(null);
+
+  /* Before the boot effect, so the observer it installs already knows whether
+     anything it sees is allowed to start. */
+  useEffect(() => {
+    const mq = window.matchMedia(HANDSET);
+    const read = (): void => {
+      handset.current = mq.matches;
+    };
+    read();
+    mq.addEventListener('change', read);
+    return () => mq.removeEventListener('change', read);
+  }, []);
 
   /* Boot on sight rather than at load. It pulls Chart.js off a CDN and samples
      two thousand deviates to draw itself, and a reader who never gets this far
@@ -143,9 +169,14 @@ export default function DeviationFrame({ src, href, title, poster, posterAlt, no
       setLive(true);
       stop();
     };
+    ask.current = boot;
+
+    /* On a handset nothing arms: the poster stands until the press above calls
+       the same boot by hand. Checked here rather than at install, so a phone
+       turned on its side is a phone the frame may start itself on. */
     const arm = (): void => {
       window.clearTimeout(timer);
-      if (seen) timer = window.setTimeout(boot, 220);
+      if (seen && !handset.current) timer = window.setTimeout(boot, 220);
     };
     const io = new IntersectionObserver(
       (entries) => {
@@ -160,6 +191,7 @@ export default function DeviationFrame({ src, href, title, poster, posterAlt, no
     return () => {
       stop();
       release();
+      ask.current = null;
     };
   }, []);
 
@@ -233,7 +265,10 @@ export default function DeviationFrame({ src, href, title, poster, posterAlt, no
 
   return (
     <>
-      <div className="stage stage--dev">
+      {/* One attribute for both of the things a booted frame changes down
+          here: the box goes back to the height it scrolls at, and the swipe
+          instruction becomes true again. */}
+      <div className="stage stage--dev" data-live={live || undefined}>
         <span className="stage__label">Two distributions</span>
         {/* The frame's own height is the stylesheet's, from the same ratio and
             the same floor this component clamps to. Setting it from here would
@@ -247,8 +282,15 @@ export default function DeviationFrame({ src, href, title, poster, posterAlt, no
             {/* A transform does not resize the box it is on, and the scroll area
               of the frame above is measured off boxes. So the drawn width is
               stated here, and the only thing that scrolls is what is really
-              wider than the card. */}
-            <div className="devframe__fit" style={{ width: `${Math.round(W * scale)}px` }}>
+              wider than the card.
+
+              Only while a frame is drawn, though. A poster is an image and
+              fits whatever it is given; stating a width for it would be
+              claiming a scroll the still does not have. */}
+            <div
+              className="devframe__fit"
+              style={live ? { width: `${Math.round(W * scale)}px` } : undefined}
+            >
               {live ? (
                 <iframe
                   ref={frame}
@@ -280,6 +322,16 @@ export default function DeviationFrame({ src, href, title, poster, posterAlt, no
               )}
             </div>
           </div>
+          {/* In the corner rather than across the middle, because the poster
+              under it is the chart: a scrim over a chart, advertising the same
+              chart, is a curtain in front of the thing it is selling. In the
+              document at every width and shown by the stylesheet only where
+              nothing starts by itself. */}
+          {!live && (
+            <button className="devgo" type="button" onClick={() => ask.current?.()}>
+              Run the 2015 file
+            </button>
+          )}
         </div>
         {/* Only true where the frame actually pans, which the stylesheet knows
             as the same 765px the drawn height stops changing at. It is in the

--- a/src/scripts/deep.ts
+++ b/src/scripts/deep.ts
@@ -1,0 +1,87 @@
+/**
+ * The project cards, folded on a phone.
+ *
+ * See Deep.astro for why the fold exists. This file is only the switch: below
+ * 620 each card gets `data-fold`, which the stylesheet reads to make the
+ * wrapper a real box and draw the press, and the wrapper gets
+ * `hidden="until-found"`, which is what keeps find-in-page working through it.
+ *
+ * Both attributes are written here rather than served. A card folded in the
+ * markup is a card a scriptless phone cannot open, and a press drawn in the
+ * markup is a press that would do nothing there.
+ */
+
+const NARROW = '(width <= 620px)';
+
+function fold(deep: HTMLElement): void {
+  deep.setAttribute('hidden', 'until-found');
+  /* The press is about to be undrawn, so the focus it holds has to land
+     somewhere. It lands here, on the thing that just arrived. */
+  deep.tabIndex = -1;
+  deep.closest('.card')?.setAttribute('data-fold', '');
+}
+
+function unfold(deep: HTMLElement, move: boolean): void {
+  deep.removeAttribute('hidden');
+  if (move) {
+    /* Two orderings that look identical and are not. Focus has to leave the
+       press before the press is undrawn: hiding the focused element schedules
+       a fixup that puts the caret on the body, and that fixup lands after this
+       call rather than before it.
+       The rect is read because dropping `hidden` does not recompute style on
+       its own, and a box the browser still believes is content-visibility:
+       hidden refuses focus. */
+    deep.getBoundingClientRect();
+    deep.focus();
+  }
+  deep.closest('.card')?.removeAttribute('data-fold');
+  if (!move) deep.removeAttribute('tabindex');
+}
+
+export function installDeep(): void {
+  const deeps = [...document.querySelectorAll<HTMLElement>('[data-deep]')];
+  if (!deeps.length) return;
+
+  const narrow = matchMedia(NARROW);
+  /* Asked once is asked. A reader who opens a card and then turns the phone
+     twice should not have to open it again. */
+  const opened = new WeakSet<HTMLElement>();
+
+  for (const deep of deeps) {
+    const go = deep.previousElementSibling;
+    go?.addEventListener('click', () => {
+      opened.add(deep);
+      unfold(deep, true);
+    });
+
+    /* Find-in-page reached a word inside a folded card. The browser is about
+       to undo the hiding on its own; the press over it has to go with it. */
+    deep.addEventListener('beforematch', () => {
+      opened.add(deep);
+      unfold(deep, false);
+    });
+  }
+
+  const sync = (): void => {
+    for (const deep of deeps) {
+      if (narrow.matches && !opened.has(deep)) fold(deep);
+      else unfold(deep, false);
+    }
+  };
+
+  /* A link into a card lands on the card, and a card showing nothing but its
+     name has not answered the link. */
+  const reveal = (): void => {
+    const id = decodeURIComponent(location.hash.slice(1));
+    const deep = id ? document.getElementById(id)?.querySelector<HTMLElement>('[data-deep]') : null;
+    if (deep) {
+      opened.add(deep);
+      unfold(deep, false);
+    }
+  };
+
+  narrow.addEventListener('change', sync);
+  window.addEventListener('hashchange', reveal);
+  sync();
+  reveal();
+}

--- a/src/scripts/ledger.ts
+++ b/src/scripts/ledger.ts
@@ -1,0 +1,106 @@
+/**
+ * The finished jobs, folded on a phone.
+ *
+ * Seven roles a reader has already formed an opinion about is 1,355px at 390,
+ * and all of it stands between the current job and the degree behind it. Each
+ * one becomes a ledger line - dates, employer, job title - and the rest of the
+ * entry arrives on a tap.
+ *
+ * The disclosure is assembled here rather than written into the page, because
+ * a `<details>` in the markup is a `<details>` a desktop reader can close, and
+ * above 620 none of these rows is meant to be a control at all. Built under the
+ * media query instead, the wide layout keeps exactly the boxes it always had.
+ * The price is that a phone with no script reads the log whole, which is the
+ * right way round for that failure to fall.
+ */
+
+const NARROW = '(width <= 620px)';
+
+/* The stack line is "job title · thing · thing", glued by the non-breaking
+   separator `dots` puts in. Folded, the row wants the title and none of the
+   rest, so the tail goes in a span the stylesheet can drop. Splitting it here
+   rather than in the template keeps the served markup one text node, which is
+   one fewer place for a stray space to land beside the separator. */
+const GLUE = '\u00a0\u00b7';
+
+function splitStack(p: Element): void {
+  if (p.querySelector('.role__tail')) return;
+  const text = p.textContent ?? '';
+  const cut = text.indexOf(GLUE);
+  if (cut < 0) return;
+
+  const tail = document.createElement('span');
+  tail.className = 'role__tail';
+  tail.textContent = text.slice(cut);
+  p.textContent = text.slice(0, cut);
+  p.append(tail);
+}
+
+function fold(li: HTMLElement): void {
+  if (li.querySelector(':scope > .fold')) return;
+  const when = li.querySelector<HTMLElement>(':scope > .role__when');
+  const box = li.querySelector<HTMLElement>(':scope > div');
+  const h3 = box?.querySelector('h3');
+  const stack = box?.querySelector('.stack');
+  if (!when || !box || !h3 || !stack) return;
+
+  splitStack(stack);
+
+  const head = document.createElement('div');
+  head.className = 'fold__hd';
+  head.append(h3, stack);
+
+  const sum = document.createElement('summary');
+  sum.className = 'fold__sum';
+  sum.append(when, head);
+
+  const d = document.createElement('details');
+  d.className = 'fold';
+  d.append(sum, box);
+  li.append(d);
+}
+
+/* Every move above, backwards. A phone turned on its side crosses the
+   breakpoint, and a row left half-folded on the wide layout would be a row
+   with its own heading in the date column. */
+function unfold(li: HTMLElement): void {
+  const d = li.querySelector<HTMLDetailsElement>(':scope > .fold');
+  const when = d?.querySelector('.role__when');
+  const head = d?.querySelector('.fold__hd');
+  const box = d?.querySelector<HTMLElement>(':scope > div');
+  if (!d || !when || !head || !box) return;
+
+  box.prepend(...head.childNodes);
+  li.append(when, box);
+  d.remove();
+}
+
+/* A link into the log lands on the row it names, and a row showing nothing but
+   its dates has not answered the link. */
+function reveal(hash: string): void {
+  const id = decodeURIComponent(hash.slice(1));
+  const d = id
+    ? document.getElementById(id)?.querySelector<HTMLDetailsElement>(':scope > .fold')
+    : null;
+  if (d) d.open = true;
+}
+
+export function installLedger(): void {
+  const tl = document.querySelector<HTMLElement>('.tl');
+  if (!tl) return;
+
+  const narrow = matchMedia(NARROW);
+
+  const sync = (): void => {
+    for (const li of tl.querySelectorAll<HTMLElement>(':scope > .role')) {
+      if (narrow.matches) fold(li);
+      else unfold(li);
+    }
+    tl.toggleAttribute('data-fold', narrow.matches);
+    if (narrow.matches) reveal(location.hash);
+  };
+
+  narrow.addEventListener('change', sync);
+  window.addEventListener('hashchange', () => reveal(location.hash));
+  sync();
+}

--- a/src/scripts/motion.ts
+++ b/src/scripts/motion.ts
@@ -1,4 +1,5 @@
 import { installAssembly } from './assembly';
+import { installDeep } from './deep';
 import { installLedger } from './ledger';
 import { installSwipe } from './swipe';
 import { installTunnel } from './tunnel';
@@ -507,3 +508,4 @@ installAssembly();
 installTunnel();
 installSwipe();
 installLedger();
+installDeep();

--- a/src/scripts/motion.ts
+++ b/src/scripts/motion.ts
@@ -1,4 +1,5 @@
 import { installAssembly } from './assembly';
+import { installSwipe } from './swipe';
 import { installTunnel } from './tunnel';
 import { springKeyframes } from './spring';
 import { installHero } from '../heroes/runtime';
@@ -503,3 +504,4 @@ installKonami();
 installHeroCanvas();
 installAssembly();
 installTunnel();
+installSwipe();

--- a/src/scripts/motion.ts
+++ b/src/scripts/motion.ts
@@ -1,4 +1,5 @@
 import { installAssembly } from './assembly';
+import { installLedger } from './ledger';
 import { installSwipe } from './swipe';
 import { installTunnel } from './tunnel';
 import { springKeyframes } from './spring';
@@ -505,3 +506,4 @@ installHeroCanvas();
 installAssembly();
 installTunnel();
 installSwipe();
+installLedger();

--- a/src/scripts/swipe.ts
+++ b/src/scripts/swipe.ts
@@ -1,0 +1,48 @@
+/**
+ * The edges of a swipe row.
+ *
+ * The row itself is CSS and needs nothing from here: it scrolls, it snaps and
+ * it works with this file never loaded. What the script adds is the pair of
+ * fades, and only the truthful ones - a side is marked when there is really
+ * more row behind it, so the first card keeps its own left edge until the
+ * reader has pushed it, and the last one keeps its right.
+ *
+ * There is no width test in here. Above the breakpoint the row is
+ * `display: contents` and has no scroll of its own, so its overflow is zero,
+ * so neither side is ever marked. The stylesheet decides where the pattern is
+ * on and this agrees with it by arithmetic rather than by keeping a copy of
+ * the number.
+ */
+
+/* A card can sit a fraction of a pixel off the end of a snap, and a fade drawn
+   over an edge that is already at the end is a fade that lies. */
+const SLACK = 2;
+
+export function installSwipe(): void {
+  const rows = document.querySelectorAll<HTMLElement>('.swipe__row');
+  if (!rows.length) return;
+
+  for (const row of rows) {
+    const wrap = row.parentElement;
+    if (!wrap) continue;
+
+    let ticking = false;
+    const paint = (): void => {
+      ticking = false;
+      const over = row.scrollWidth - row.clientWidth;
+      const x = row.scrollLeft;
+      wrap.toggleAttribute('data-l', over > SLACK && x > SLACK);
+      wrap.toggleAttribute('data-r', over > SLACK && x < over - SLACK);
+    };
+
+    const tick = (): void => {
+      if (ticking) return;
+      ticking = true;
+      requestAnimationFrame(paint);
+    };
+
+    row.addEventListener('scroll', tick, { passive: true });
+    window.addEventListener('resize', tick, { passive: true });
+    paint();
+  }
+}

--- a/src/sections/Playground.astro
+++ b/src/sections/Playground.astro
@@ -27,13 +27,17 @@ const grinchPoster = await sources('legacy-grinchjump', POSTER_W, POSTER_S);
    arrives, and stands in for it permanently where no script runs. */
 const deviationPoster = await sources('legacy-deviation', POSTER_W, POSTER_S);
 
-/* The dashboard sits in the wider of a 0.58 / 1 split: 740px at the maximum. */
-const RZ_LEAD_W = [480, 740, 1080, 1480];
-const RZ_LEAD_S = '(min-width: 1400px) 740px, (min-width: 900px) 60vw, 92vw';
+/* The dashboard sits in the wider of a 0.58 / 1 split: 740px at the maximum.
+   Below 620 the set is a swipe row and every frame in it is a 78vw card, which
+   is the last clause in each of these lists. */
+const RZ_LEAD_W = [320, 480, 740, 1080, 1480];
+const RZ_LEAD_S =
+  '(min-width: 1400px) 740px, (min-width: 900px) 60vw, (min-width: 621px) 92vw, 78vw';
 
 /* The pair halves the full measure: 605px each at the maximum. */
-const RZ_PAIR_W = [400, 605, 900, 1210];
-const RZ_PAIR_S = '(min-width: 1400px) 605px, (min-width: 760px) 46vw, 92vw';
+const RZ_PAIR_W = [320, 400, 605, 900, 1210];
+const RZ_PAIR_S =
+  '(min-width: 1400px) 605px, (min-width: 760px) 46vw, (min-width: 621px) 92vw, 78vw';
 
 const rzShots = [
   rendezvous.lead.asset,
@@ -148,44 +152,53 @@ const rzShots = [
       <p class="stack">{dots(rendezvous.k)}</p>
     </div>
 
-    <figure class="rz__lead">
-      <Picture
-        src={asset(rendezvous.lead.asset)}
-        alt={rendezvous.lead.alt}
-        widths={RZ_LEAD_W}
-        sizes={RZ_LEAD_S}
-        formats={['avif']}
-        fallbackFormat="webp"
-        loading="lazy"
-        decoding="async"
-      />
-      <figcaption>{rendezvous.lead.cap}</figcaption>
-    </figure>
-
     {
-      rendezvous.pairs.map((pr) => (
-        <figure class="rz__pair">
-          <div class="rz__two">
-            {pr.shots.map((sh) => (
-              <div class="rz__shot">
-                <Picture
-                  src={asset(sh.asset)}
-                  alt={sh.alt}
-                  widths={RZ_PAIR_W}
-                  sizes={RZ_PAIR_S}
-                  formats={['avif']}
-                  fallbackFormat="webp"
-                  loading="lazy"
-                  decoding="async"
-                />
-                <span class="rz__theme">{sh.label}</span>
-              </div>
-            ))}
-          </div>
-          <figcaption>{pr.cap}</figcaption>
-        </figure>
-      ))
+      /* Three frames, and on a phone they are a row rather than a column. The
+        wrapper is two elements of nothing above 620 - see .swipe - so the
+        block below that width is the only place this is a scroller. */
     }
+    <div class="swipe">
+      <div class="swipe__row">
+        <figure class="rz__lead">
+          <Picture
+            src={asset(rendezvous.lead.asset)}
+            alt={rendezvous.lead.alt}
+            widths={RZ_LEAD_W}
+            sizes={RZ_LEAD_S}
+            formats={['avif']}
+            fallbackFormat="webp"
+            loading="lazy"
+            decoding="async"
+          />
+          <figcaption>{rendezvous.lead.cap}</figcaption>
+        </figure>
+
+        {
+          rendezvous.pairs.map((pr) => (
+            <figure class="rz__pair">
+              <div class="rz__two">
+                {pr.shots.map((sh) => (
+                  <div class="rz__shot">
+                    <Picture
+                      src={asset(sh.asset)}
+                      alt={sh.alt}
+                      widths={RZ_PAIR_W}
+                      sizes={RZ_PAIR_S}
+                      formats={['avif']}
+                      fallbackFormat="webp"
+                      loading="lazy"
+                      decoding="async"
+                    />
+                    <span class="rz__theme">{sh.label}</span>
+                  </div>
+                ))}
+              </div>
+              <figcaption>{pr.cap}</figcaption>
+            </figure>
+          ))
+        }
+      </div>
+    </div>
 
     <Inspect by="astro:assets Picture" assets={rzShots} />
   </article>

--- a/src/sections/Projects.astro
+++ b/src/sections/Projects.astro
@@ -1,6 +1,7 @@
 ---
 import { Picture } from 'astro:assets';
 import Claim from '../components/Claim.astro';
+import Deep from '../components/Deep.astro';
 import Assembly from '../components/Assembly.astro';
 import Inspect from '../components/Inspect.astro';
 import Section from '../components/Section.astro';
@@ -153,60 +154,66 @@ const elderFrames: SwitchFrame[] = await Promise.all(
       </div>
 
       <div class="card__copy">
-        <div class="card__cols">
-          <div class="card__body">
-            {saltline.prose.map((p) => <p>{p}</p>)}
+        <Deep label="Read on · wind tunnel, six frames">
+          <div class="card__cols">
+            <div class="card__body">
+              {saltline.prose.map((p) => <p>{p}</p>)}
+            </div>
+            <div class="card__aside">
+              <WindTunnel />
+              <details class="notes">
+                <summary>Technical notes</summary>
+                <dl class="specs">
+                  {
+                    saltline.plate.map(([k, v]) => (
+                      <div>
+                        <dt>{k}</dt>
+                        <dd>{v}</dd>
+                      </div>
+                    ))
+                  }
+                  <div>
+                    <dt>Open</dt>
+                    <dd><a href={saltline.href} target="_blank" rel="noopener">saltline.app</a></dd>
+                  </div>
+                </dl>
+              </details>
+            </div>
           </div>
-          <div class="card__aside">
-            <WindTunnel />
-            <details class="notes">
-              <summary>Technical notes</summary>
-              <dl class="specs">
-                {
-                  saltline.plate.map(([k, v]) => (
-                    <div>
-                      <dt>{k}</dt>
-                      <dd>{v}</dd>
-                    </div>
-                  ))
-                }
-                <div>
-                  <dt>Open</dt>
-                  <dd><a href={saltline.href} target="_blank" rel="noopener">saltline.app</a></dd>
-                </div>
-              </dl>
-            </details>
-          </div>
-        </div>
 
-        <p class="card__lede">{saltline.framesLede}</p>
-        <p class="cue">{saltline.framesCue}</p>
-        {
-          /* Hydrated a screenful early, like every island below the fold, so
+          <p class="card__lede">{saltline.framesLede}</p>
+          <p class="cue">{saltline.framesCue}</p>
+          {
+            /* Hydrated a screenful early, like every island below the fold, so
             the mount is finished before the reader gets here. */
-        }
-        <Arc client:visible={{ rootMargin: '600px' }} frames={arcFrames} note={saltline.arcNote} />
-        <Inspect by="Arc.tsx" assets={arcFrames.map((f) => `saltline-arc-${f.key}`)} />
+          }
+          <Arc
+            client:visible={{ rootMargin: '600px' }}
+            frames={arcFrames}
+            note={saltline.arcNote}
+          />
+          <Inspect by="Arc.tsx" assets={arcFrames.map((f) => `saltline-arc-${f.key}`)} />
 
-        <div class="inset">
-          <div class="shot shot--inset">
-            <Picture
-              src={asset('saltline-proof-panel')}
-              alt="The same 16:46 frame uncropped, with the development panel down the left edge: time of day, sea state, wind angle, crest sharpness and seed. Three raider contacts are marked on the nav chart."
-              widths={INSET_W}
-              sizes={INSET_S}
-              formats={['avif']}
-              fallbackFormat="webp"
-              loading="lazy"
-              decoding="async"
-            />
+          <div class="inset">
+            <div class="shot shot--inset">
+              <Picture
+                src={asset('saltline-proof-panel')}
+                alt="The same 16:46 frame uncropped, with the development panel down the left edge: time of day, sea state, wind angle, crest sharpness and seed. Three raider contacts are marked on the nav chart."
+                widths={INSET_W}
+                sizes={INSET_S}
+                formats={['avif']}
+                fallbackFormat="webp"
+                loading="lazy"
+                decoding="async"
+              />
+            </div>
+            <Inspect by="astro:assets Picture" assets="saltline-proof-panel" />
+            <div class="inset__body">
+              <h4>{saltline.proof.t}</h4>
+              {saltline.proof.body.map((p) => <p>{p}</p>)}
+            </div>
           </div>
-          <Inspect by="astro:assets Picture" assets="saltline-proof-panel" />
-          <div class="inset__body">
-            <h4>{saltline.proof.t}</h4>
-            {saltline.proof.body.map((p) => <p>{p}</p>)}
-          </div>
-        </div>
+        </Deep>
       </div>
     </article>
 
@@ -251,65 +258,70 @@ const elderFrames: SwitchFrame[] = await Promise.all(
       </div>
 
       <div class="card__copy">
-        <div class="card__cols">
-          <div class="card__body">
-            {ember.prose.map((p) => <p>{p}</p>)}
+        <Deep label="Read on · seven regions, two clients">
+          <div class="card__cols">
+            <div class="card__body">
+              {ember.prose.map((p) => <p>{p}</p>)}
+            </div>
+            <div class="card__aside">
+              <details class="notes">
+                <summary>Technical notes</summary>
+                <dl class="specs">
+                  {
+                    ember.plate.map(([k, v]) => (
+                      <div>
+                        <dt>{k}</dt>
+                        <dd>{v}</dd>
+                      </div>
+                    ))
+                  }
+                  <div>
+                    <dt>Open</dt>
+                    <dd>
+                      <a href={ember.href} target="_blank" rel="noopener">emberwilds-web.fly.dev</a>
+                    </dd>
+                  </div>
+                </dl>
+              </details>
+            </div>
           </div>
-          <div class="card__aside">
-            <details class="notes">
-              <summary>Technical notes</summary>
-              <dl class="specs">
-                {
-                  ember.plate.map(([k, v]) => (
-                    <div>
-                      <dt>{k}</dt>
-                      <dd>{v}</dd>
-                    </div>
-                  ))
-                }
-                <div>
-                  <dt>Open</dt>
-                  <dd>
-                    <a href={ember.href} target="_blank" rel="noopener">emberwilds-web.fly.dev</a>
-                  </dd>
-                </div>
-              </dl>
-            </details>
-          </div>
-        </div>
 
-        <p class="card__lede">{ember.framesLede}</p>
-        <p class="cue">{ember.framesCue}</p>
-        <FrameSwitcher
-          client:visible={{ rootMargin: '600px' }}
-          label="Ember Wilds regions"
-          frames={emberFrames}
-        />
-        <Inspect by="FrameSwitcher.tsx" assets={emberFrames.map((f) => emberAsset[f.key] ?? '')} />
+          <p class="card__lede">{ember.framesLede}</p>
+          <p class="cue">{ember.framesCue}</p>
+          <FrameSwitcher
+            client:visible={{ rootMargin: '600px' }}
+            label="Ember Wilds regions"
+            frames={emberFrames}
+          />
+          <Inspect
+            by="FrameSwitcher.tsx"
+            assets={emberFrames.map((f) => emberAsset[f.key] ?? '')}
+          />
 
-        <div class="inset">
-          <div class="shot shot--inset">
-            <Picture
-              src={asset('ember-proof-two-players')}
-              alt="Two Ember Wilds clients side by side in the Hearthvale. Each character has a speech bubble above it and the same two lines appear in the chat log at bottom left."
-              widths={INSET_W}
-              sizes={INSET_S}
-              formats={['avif']}
-              fallbackFormat="webp"
-              loading="lazy"
-              decoding="async"
-            />
+          <div class="inset">
+            <div class="shot shot--inset">
+              <Picture
+                src={asset('ember-proof-two-players')}
+                alt="Two Ember Wilds clients side by side in the Hearthvale. Each character has a speech bubble above it and the same two lines appear in the chat log at bottom left."
+                widths={INSET_W}
+                sizes={INSET_S}
+                formats={['avif']}
+                fallbackFormat="webp"
+                loading="lazy"
+                decoding="async"
+              />
+            </div>
+            <Inspect by="astro:assets Picture" assets="ember-proof-two-players" />
+            <div class="inset__body">
+              <h4>{ember.proof.t}</h4>
+              {
+                ember.proof.body.map((p, i) => (
+                  <p>{i === 0 ? <Claim of="ember.two">{p}</Claim> : p}</p>
+                ))
+              }
+            </div>
           </div>
-          <Inspect by="astro:assets Picture" assets="ember-proof-two-players" />
-          <div class="inset__body">
-            <h4>{ember.proof.t}</h4>
-            {
-              ember.proof.body.map((p, i) => (
-                <p>{i === 0 ? <Claim of="ember.two">{p}</Claim> : p}</p>
-              ))
-            }
-          </div>
-        </div>
+        </Deep>
       </div>
     </article>
 
@@ -342,25 +354,27 @@ const elderFrames: SwitchFrame[] = await Promise.all(
 
         <Skim {...hidamari.skim} ev="hidamari.proof" />
 
-        <div class="card__body">
-          {hidamari.prose.map((p) => <p>{p}</p>)}
-        </div>
+        <Deep label="Read on · four plates, one frame">
+          <div class="card__body">
+            {hidamari.prose.map((p) => <p>{p}</p>)}
+          </div>
 
-        <Assembly />
+          <Assembly />
 
-        <details class="notes">
-          <summary>Technical notes</summary>
-          <dl class="specs">
-            {
-              hidamari.plate.map(([k, v]) => (
-                <div>
-                  <dt>{k}</dt>
-                  <dd>{v}</dd>
-                </div>
-              ))
-            }
-          </dl>
-        </details>
+          <details class="notes">
+            <summary>Technical notes</summary>
+            <dl class="specs">
+              {
+                hidamari.plate.map(([k, v]) => (
+                  <div>
+                    <dt>{k}</dt>
+                    <dd>{v}</dd>
+                  </div>
+                ))
+              }
+            </dl>
+          </details>
+        </Deep>
       </div>
     </article>
 
@@ -378,32 +392,34 @@ const elderFrames: SwitchFrame[] = await Promise.all(
 
         <Skim {...elderwood.skim} ev="elderwood.proof" />
 
-        <div class="card__body">
-          {elderwood.prose.map((p) => <p>{p}</p>)}
-        </div>
+        <Deep label="Read on · three captures">
+          <div class="card__body">
+            {elderwood.prose.map((p) => <p>{p}</p>)}
+          </div>
 
-        <details class="notes">
-          <summary>Technical notes</summary>
-          <dl class="specs">
-            {
-              elderwood.plate.map(([k, v]) => (
-                <div>
-                  <dt>{k}</dt>
-                  <dd>{v}</dd>
-                </div>
-              ))
-            }
-          </dl>
-        </details>
+          <details class="notes">
+            <summary>Technical notes</summary>
+            <dl class="specs">
+              {
+                elderwood.plate.map(([k, v]) => (
+                  <div>
+                    <dt>{k}</dt>
+                    <dd>{v}</dd>
+                  </div>
+                ))
+              }
+            </dl>
+          </details>
 
-        <p class="card__lede">{elderwood.framesLede}</p>
-        <p class="cue">{elderwood.framesCue}</p>
-        <FrameSwitcher
-          client:visible={{ rootMargin: '600px' }}
-          label="Elderwood Vale captures"
-          frames={elderFrames}
-        />
-        <Inspect by="FrameSwitcher.tsx" assets={elderFrames.map((f) => `elderwood-${f.key}`)} />
+          <p class="card__lede">{elderwood.framesLede}</p>
+          <p class="cue">{elderwood.framesCue}</p>
+          <FrameSwitcher
+            client:visible={{ rootMargin: '600px' }}
+            label="Elderwood Vale captures"
+            frames={elderFrames}
+          />
+          <Inspect by="FrameSwitcher.tsx" assets={elderFrames.map((f) => `elderwood-${f.key}`)} />
+        </Deep>
       </div>
     </article>
   </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -5077,14 +5077,19 @@ span.buoy__p {
     display: none;
   }
 
+  /* 3.2rem is more than the wide layout's own floor, and it was buying air a
+     phone does not need to be sold: every section here changes ground colour,
+     so the join is already unmissable and the padding on both sides of it is
+     only how long the reader waits at it. Seven sections, two edges each, and
+     it was 717px of the page. */
   .sec {
-    padding-block: 3.2rem;
+    padding-block: 2.2rem;
   }
 
   .head {
     grid-template-columns: 1fr;
     gap: 0.8rem;
-    margin-bottom: 2.2rem;
+    margin-bottom: 1.6rem;
   }
 
   .head__t {
@@ -5095,8 +5100,12 @@ span.buoy__p {
     font-size: clamp(1.7rem, 7.4vw, 2.4rem);
   }
 
+  /* Four columns became one, so the rule under the last row is no longer the
+     rule under all of them, and the clamp's floor was sized for the wide
+     version's single band. */
   .vitals {
     grid-template-columns: 1fr;
+    margin-bottom: 1.2rem;
   }
 
   .about__copy p {
@@ -5265,6 +5274,19 @@ span.buoy__p {
 
   .contact h2 {
     font-size: 20vw;
+  }
+
+  /* Both clamps bottom out well above what a phone needs. The rule under the
+     colophon already separates it from the links, and 2rem of nothing above a
+     sub-heading is a gap a thumb has to travel rather than a distinction it
+     can see. */
+  .foot {
+    margin-top: 1.6rem;
+    padding-top: 1rem;
+  }
+
+  .rz + .earlier__h {
+    margin-top: 1.3rem;
   }
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1531,7 +1531,10 @@ summary,
   line-height: 1.45;
 }
 
-.skim + .card__body {
+.skim + .card__body,
+/* Same gap with the fold wrapper in between. It is not a box on a wide screen,
+   so it cannot carry the margin itself, and it breaks the adjacency. */
+.skim ~ .deep > .card__body:first-child {
   margin-top: 1rem;
 }
 
@@ -1555,7 +1558,8 @@ summary,
   margin-top: 0.35rem;
 }
 
-.notes > summary {
+.notes > summary,
+.deep__go {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
@@ -1578,7 +1582,8 @@ summary,
   display: none;
 }
 
-.notes > summary:hover {
+.notes > summary:hover,
+.deep__go:hover {
   color: var(--on-paper);
   background: var(--paper);
   border-color: var(--paper);
@@ -1587,7 +1592,8 @@ summary,
 /* Two strokes rotated into a chevron, so the state is legible without reading
    the label twice. It points down when there is more below and up when the
    list is already showing. */
-.notes > summary::after {
+.notes > summary::after,
+.deep__go::after {
   content: '';
   width: 0.42em;
   height: 0.42em;
@@ -1605,6 +1611,29 @@ summary,
 
 .notes[open] > .specs {
   margin-top: 0.85rem;
+}
+
+/* ── 8b. THE FOLD ────────────────────────────────────────────────────────
+   See Deep.astro. Above the breakpoint the wrapper is not a box at all, so
+   the four cards lay out exactly as they did and the press is not drawn.
+   Below it the wrapper is a real box whether it is open or shut, because a
+   box is both the only thing `hidden="until-found"` can hide and the only
+   thing that can hold the focus the press hands over. */
+.deep {
+  display: contents;
+}
+
+.deep__go {
+  display: none;
+  /* The pill it borrows is worn by a summary, which has no fill of its own. A
+     button does: the UA grey underneath took the label from 8.2:1 to 3.1:1. */
+  background: none;
+  margin-top: 0.9rem;
+}
+
+.deep:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 4px;
 }
 
 .shot {
@@ -5287,6 +5316,17 @@ span.buoy__p {
 
   .rz + .earlier__h {
     margin-top: 1.3rem;
+  }
+
+  /* Content visibility does nothing to an element that generates no box of its
+     own, and neither does focus. Both are needed here, so on a phone the
+     wrapper is a box the whole time rather than only while it is shut. */
+  .deep {
+    display: block;
+  }
+
+  .card[data-fold] .deep__go {
+    display: inline-flex;
   }
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -5097,6 +5097,67 @@ span.buoy__p {
     border-bottom: 0;
   }
 
+  /* The finished jobs, folded into a ledger: dates, employer, job title, and
+     the entry itself one tap away. The disclosure is assembled by script - see
+     ledger.ts for why it is not in the markup - so `data-fold` is the row
+     saying the shape below actually got built. Without it the log stays whole
+     and these rules describe nothing. */
+  .tl[data-fold] .role {
+    padding-block: 0;
+  }
+
+  .fold__sum {
+    position: relative;
+    padding: 0.72rem 1.5rem 0.72rem 0;
+    cursor: pointer;
+    list-style: none;
+  }
+
+  .fold__sum::-webkit-details-marker {
+    display: none;
+  }
+
+  /* The same two strokes the spec lists fold behind, so a fold reads as a fold
+     wherever the page puts one. */
+  .fold__sum::after {
+    content: '';
+    position: absolute;
+    top: 1.15rem;
+    right: 0.3rem;
+    width: 0.42rem;
+    height: 0.42rem;
+    border-right: 2px solid var(--on-paper-3);
+    border-bottom: 2px solid var(--on-paper-3);
+    transform: rotate(45deg);
+    transition: transform var(--dur-1) var(--ease);
+  }
+
+  .fold[open] > .fold__sum::after {
+    margin-top: 0.16rem;
+    transform: rotate(-135deg);
+  }
+
+  /* The date leads the line rather than sitting in a column that no longer
+     exists, so it loses the offsets that were holding it level with one. */
+  .fold__sum .role__when {
+    margin: 0;
+    padding: 0;
+  }
+
+  .fold__hd {
+    margin-top: 0.16rem;
+  }
+
+  /* Shut, the line is the job title and stops. Opening it lets the stack back
+     onto the end of its own sentence. */
+  .fold:not([open]) .role__tail {
+    display: none;
+  }
+
+  .fold > div {
+    padding-bottom: 0.85rem;
+  }
+
   .edu {
     padding: 1.05rem;
   }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3994,11 +3994,23 @@ button.toolbar__link {
   }
 }
 
-/* Two dashboards side by side stop being readable long before the layout
-   stops fitting them. Below 620 they go one above the other, full width. */
+/* This used to stack the pair below 620, on the reasoning that two dashboards
+   side by side stop being readable long before the layout stops fitting them.
+   The swipe row answers that differently. Stacked inside a 78vw card the pair
+   is twice the height of the lead beside it, and a row is only as short as its
+   tallest card: 243px of empty ground under the dashboard, which is the first
+   thing a thumb meets. Side by side the three cards are 253, 155 and 190, and
+   the argument the pair exists to make - same screen, one toggle apart - is
+   the one thing a shot this small still carries, better adjacent than
+   separated by a scroll. */
 @media (width <= 620px) {
-  .rz__two {
-    grid-template-columns: minmax(0, 1fr);
+  /* Sized for a 605px frame, and a third of the width of a 143px one. The
+     type is already at the floor, so the room comes out of the padding. */
+  .rz__theme {
+    top: 0.35rem;
+    left: 0.35rem;
+    padding: 0.15rem 0.32rem;
+    letter-spacing: 0.03em;
   }
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4931,6 +4931,13 @@ span.buoy__p {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
+  /* 2.1rem is the gap under a one-line key on a wide card. Under a two-row key
+     on a phone it is a hole, and the control it separates is the one thing in
+     the figure a thumb is meant to find. */
+  .asm__scrub {
+    margin-top: 1.1rem;
+  }
+
   /* /socket-canvas/public/index.html is thirty-two characters, and next to it
      a name gets three. The address takes the row and everything else stacks
      under it. */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3397,6 +3397,35 @@ summary,
   margin-top: 0;
 }
 
+/* The press that unfolds the controls. Same rule as the deviation card's: in
+   the document at every width, drawn only where the controls start folded, and
+   gone once they are open - wide, it would be a button for something already on
+   screen. The base has to stand above the query, or `display: none` wins the
+   cascade on source order and the button is never drawn at all. */
+.typer__go {
+  display: none;
+  align-self: start;
+  align-items: center;
+  margin-top: 0.9rem;
+}
+
+/* A field, a slider and three presets are 191px, which on a 390 screen is the
+   card's whole second half spent on controls nobody has reached for. The line
+   the card exists to show is already finished above them.
+
+   The component only ever folds below this width, so the query is a second
+   lock rather than the condition: whatever the script does, the wide layout
+   keeps every control it has. */
+@media (width <= 620px) {
+  .stage--typer[data-fold] .typer {
+    display: none;
+  }
+
+  .stage--typer[data-fold] .typer__go {
+    display: inline-flex;
+  }
+}
+
 .stage--dev {
   display: grid;
   align-content: center;
@@ -3446,6 +3475,33 @@ summary,
 .devpan[data-l]::before,
 .devpan[data-r]::after {
   opacity: 1;
+}
+
+/* The press that boots the chart, in the document at every width and drawn at
+   none of them until the media query above says the frame is waiting to be
+   asked. Wide, the frame starts itself and this would be a button for
+   something that already happened. */
+.devgo {
+  position: absolute;
+  z-index: 2;
+  right: 0.55rem;
+  bottom: 0.55rem;
+  display: none;
+  align-items: center;
+  min-height: 40px;
+  padding: 0.5rem 0.85rem;
+  border: 0;
+  border-radius: var(--r-pill);
+  color: var(--on-accent);
+  background: var(--sand);
+  font: 800 0.66rem/1 var(--mono);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.devgo:hover {
+  background: var(--sand-soft);
 }
 
 /* The instruction, and it names the payoff rather than the gesture, because
@@ -3516,6 +3572,26 @@ summary,
      becomes true. */
   .devpan__cue {
     display: block;
+  }
+
+  /* Which is also exactly where half a chart at half scale stops being the
+     better offer than the whole of one. Below the crossing the poster is the
+     same seed drawn end to end at the card's width, so the box takes the
+     document's own ratio again and there is nothing to swipe at and nothing
+     to say about swiping. The live file is one press away, and pressing it is
+     what puts the box back to the height it scrolls at. */
+  .stage--dev:not([data-live]) .devframe {
+    aspect-ratio: 1330 / 595;
+    height: auto;
+    overflow-x: hidden;
+  }
+
+  .stage--dev:not([data-live]) .devpan__cue {
+    display: none;
+  }
+
+  .devgo {
+    display: inline-flex;
   }
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3396,14 +3396,19 @@ summary,
   border-color: color-mix(in srgb, var(--sand) 45%, transparent);
 }
 
-.choice--go {
+/* The fold's press is the same offer one size up, so it wears the same accent
+   - by name rather than by taking the modifier, which is how the run button
+   stays the only `.choice--go` in the card. */
+.choice--go,
+.typer__go {
   border-color: var(--sand);
   color: var(--on-accent);
   background: var(--sand);
   font-weight: 800;
 }
 
-.choice--go:hover {
+.choice--go:hover,
+.typer__go:hover {
   background: var(--sand-soft);
   border-color: var(--sand-soft);
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -206,6 +206,8 @@ html {
 }
 
 body {
+  --ground: var(--ink);
+
   margin: 0;
   min-width: 320px;
   overflow-x: hidden;
@@ -917,10 +919,16 @@ summary,
 
 /* Each ground names its own text colour and, where the sun would vanish on
    it, its own focus ring. The muted step travels with the ground too, so a
-   caption can ask for "the quiet one" without knowing what it is standing on. */
+   caption can ask for "the quiet one" without knowing what it is standing on.
+
+   `--ground` is the ground said back as a colour. Anything that has to fade
+   something out to nothing - the edge of a swipe row, a scrim over a capture -
+   needs the colour underneath it and has no business knowing which section it
+   is in. */
 .sec--paper {
   --muted: var(--on-paper-3);
   --focus: var(--on-paper);
+  --ground: var(--paper);
 
   color: var(--on-paper);
   background: var(--paper);
@@ -929,6 +937,7 @@ summary,
 .sec--paper-2 {
   --muted: var(--on-paper-3);
   --focus: var(--on-paper);
+  --ground: var(--paper-2);
 
   color: var(--on-paper);
   background: var(--paper-2);
@@ -937,6 +946,7 @@ summary,
 /* The floor the project cards stand on. */
 .sec--ink-deep {
   --muted: var(--on-ink-3);
+  --ground: var(--ink-deep);
 
   color: var(--on-ink);
   background: var(--ink-deep);
@@ -944,6 +954,7 @@ summary,
 
 .sec--ink {
   --muted: var(--on-ink-3);
+  --ground: var(--ink);
 
   color: var(--on-ink);
   background: var(--ink);
@@ -951,6 +962,7 @@ summary,
 
 .sec--ink-3 {
   --muted: var(--on-ink-3);
+  --ground: var(--ink-3);
 
   color: var(--on-ink);
   background: var(--ink-3);
@@ -959,6 +971,7 @@ summary,
 .sec--sand {
   --muted: var(--on-sand-3);
   --focus: var(--on-accent);
+  --ground: var(--sand-soft);
 
   color: var(--on-accent);
   background: var(--sand-soft);
@@ -967,6 +980,7 @@ summary,
 .sec--camel {
   --muted: var(--on-camel-3);
   --focus: var(--on-accent-2);
+  --ground: var(--camel);
 
   color: var(--on-accent-2);
   background: var(--camel);
@@ -3875,6 +3889,97 @@ button.toolbar__link {
 @media (width <= 620px) {
   .rz__two {
     grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+/* ── 12b. SWIPE ROWS ─────────────────────────────────────────────────────
+   A set of captures that stacks on a phone is a set nobody reaches the end of.
+   The rendezvous block is five dashboards one above the next: 1,361px of
+   scrolling to look at an argument that is one glance wide. Below 620 a set
+   turns on its side and becomes one row a thumb pushes.
+
+   The mechanism is the deviation card's, promoted to a pattern. Native
+   overflow with snap points - no library, no autoplay, no dots, and no
+   listener between the finger and the scroll. It works with the script off,
+   and browsers make an overflowing box a keyboard scroll region on their own,
+   so arrow keys reach it without a tabindex that would be a dead focus stop
+   at every other width.
+
+   Cards are 78vw, which is the point: the next frame is always half in view,
+   and a row that visibly continues does not need to be labelled as one.
+
+   Above the breakpoint the wrapper and the row are `display: contents`, so the
+   set lays out exactly as it did - the pattern adds two elements to the
+   document and not one box to the page. */
+.swipe,
+.swipe__row {
+  display: contents;
+}
+
+@media (width <= 620px) {
+  .swipe {
+    position: relative;
+    display: block;
+    grid-column: 1 / -1;
+  }
+
+  /* Each card is its own height. Stretched to the tallest they would all be
+     boxes the length of the longest one, which costs nothing today because a
+     frame has no ground of its own, and costs a row of empty panels the first
+     time one does. */
+  .swipe__row {
+    display: flex;
+    align-items: start;
+    gap: 0.9rem;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    overscroll-behavior-inline: contain;
+    scrollbar-width: none;
+  }
+
+  .swipe__row::-webkit-scrollbar {
+    display: none;
+  }
+
+  /* Whatever the set was made of, in the row it is a card: the frames keep
+     their own internals and only their width is decided here. */
+  .swipe__row > * {
+    flex: 0 0 78vw;
+    min-width: 0;
+    scroll-snap-align: start;
+  }
+
+  /* The fades are on the wrapper rather than the scroller, because a box
+     inside a scroller travels with the content and an edge that scrolls away
+     is not an edge. Each side is drawn only when there is really more row
+     behind it, which the script reads off the scroll position - so the first
+     card keeps its own left edge until the reader has moved it, and with no
+     script there is no fade rather than a fade that lies. */
+  .swipe::before,
+  .swipe::after {
+    content: '';
+    position: absolute;
+    z-index: 1;
+    inset-block: 0;
+    width: 2rem;
+    opacity: 0;
+    transition: opacity var(--dur-2) var(--ease);
+    pointer-events: none;
+  }
+
+  .swipe::before {
+    left: 0;
+    background: linear-gradient(to right, var(--ground), transparent);
+  }
+
+  .swipe::after {
+    right: 0;
+    background: linear-gradient(to left, var(--ground), transparent);
+  }
+
+  .swipe[data-l]::before,
+  .swipe[data-r]::after {
+    opacity: 1;
   }
 }
 


### PR DESCRIPTION
## Summary

At 390 the page was 19,377px - about twenty-three phone screens to reach the footer, most of it desktop layout scaled down rather than rethought. This cuts it to 12,465px (-35.7%) without removing a sentence or a capture. Everything that came off the page is still on the page; it is behind a press, a swipe, or a poster.

Desktop is untouched by design, and that is the main risk this PR had to retire: every rule here lives inside `@media (width <= 620px)`, and a 1440 full-page shot of `master` diffs against this branch at zero pixels.

| section | before | after | Δ |
|---|---|---|---|
| hero | 723 | 723 | 0 |
| about | 1,392 | 1,341 | -51 |
| work | 3,348 | 2,545 | -803 |
| building | 7,727 | 3,277 | -4,450 |
| playground | 4,144 | 2,628 | -1,516 |
| skills | 995 | 954 | -41 |
| contact | 1,047 | 997 | -50 |
| **document** | **19,377** | **12,465** | **-6,912** |

The target was 12,000. This lands 465 over it, and I stopped rather than cut content to close the gap: what remains is the four card skims, Notable's full entry and the three lab posters, all of which are meant to be read without asking.

## Changes

Three mechanisms carry almost all of it.

**The fold** (`Deep.astro`, `scripts/deep.ts`, section 8b of `global.css`) - below 620 each project card shows its skim and one press; the rest is `hidden="until-found"`, so find-in-page and `#p-hidamari` style fragment links still reveal it. Above 620 the wrapper is `display: contents` and the cards lay out exactly as they did. Two details worth a reviewer's eye: the wrapper stays `display: block` on narrow whether open or shut, because a `display: contents` box can hold neither `content-visibility` nor focus; and `.skim ~ .deep > .card__body:first-child` restores the 1rem gap that `.skim + .card__body` lost when a wrapper broke the adjacency. `#building` 7,727 → 3,277.

**The ledger** (`Work.astro`, `.tl .fold`) - the seven finished roles collapse to tap-to-expand rows with their entries still in the DOM. Notable, the current role, stays full. `#work` 3,348 → 2,545.

**Swipe rows** (`.swipe` / `.swipe__row`) - the rendezvous captures turn on their side: native overflow with scroll snap, 78vw cards so the next one always peeks, edge fades drawn only when there is really more row behind them. No library, no autoplay, no listener between the finger and the scroll, and it works with script off. The theme pair goes side by side inside its card rather than stacked - stacked it was twice the height of the dashboard beside it, and a row is only as tall as its tallest card. `#playground` 4,144 → 2,628.

The rest: the two inline demos become poster + tap-to-play, so no canvas boots until asked (`DeviationFrame.tsx`, `GameFrame.tsx`, `AutoTyper.tsx`); the hidamari assembly figure is compressed for thumbs; and section padding drops 51 → 35 at 390 along with a sweep of other desktop-scaled rents.

One regression fixed on the way: the typer's new fold press took `.choice--go` and landed earlier in the DOM than the submit button, so `.choice--go` inside the card stopped meaning "run". The accent is now shared by name.

`scripts/verify.mjs` ratchets the 390 budget 26,000 → 13,200 and adds six assertions for the new mechanisms - the row's snap and peek and keyboard reach, the ledger being shut with its entries kept, the fold being `until-found` rather than gone, and the press opening its own card and handing over the focus it held. It also excludes `.swipe__row` from the overflow checks, the way `.fs__scroll` already is, and races `img.decode()` against a timeout: a lazy image inside a folded card is never fetched, so its decode never settles and the 390 context hung.

## Output

Full suite, against a lab build at `f8d42a3`:

```
── 390 ──
  ok   390 the stacked set is a snapping swipe row - 1 rows, 1 scroll, 1 snap
  ok   390 a swipe card is ~78vw, so the next one peeks
  ok   390 a swipe row is reachable without a thumb
  ok   390 the finished jobs are a shut ledger with their entries still in it - 7 rows, all shut true, entries kept true
  ok   390 each project folds to hidden="until-found", not out of the document - 4 folds, until-found true, findable true
  ok   390 the press opens its own card and hands over the focus it held - shown true, press gone true, focus deep, 3 still shut
  ok   390 page fits the 13200px budget - measured 12492px

PASS - no failures
```

164 checks, 0 failures, across 1440, 390, reduced-motion, middle widths, states and loops, the polar, no-script, receipts and side B.

Desktop unchanged - 1440 full-page, both builds shot identically:

```
baseline 2880x25308   now 2880x25308
differing px 0 of 72887040 (0.0000%)  worst channel delta 0
```

Contrast passes at 390, 620 and 768 on the same formula verify uses. Reviewed on a real handset over the LAN before this went up.
