### PR TITLE
[site] Fix mobile breakpoints dropped by Safari before 16.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,14 +9,14 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "astro check && astro build",
-    "build:lab": "astro check && astro build --mode lab",
+    "build": "astro check && astro build && node scripts/check-mq.mjs",
+    "build:lab": "astro check && astro build --mode lab && node scripts/check-mq.mjs",
     "preview": "astro preview",
     "astro": "astro",
     "images": "node scripts/prepare-images.mjs",
     "poster:deviation": "node scripts/capture-deviation.mjs",
     "receipts": "node scripts/receipts.mjs",
-    "lint": "eslint . && prettier --check .",
+    "lint": "eslint . && prettier --check . && node scripts/check-mq.mjs",
     "format": "prettier --write .",
     "check": "astro check",
     "verify": "node scripts/verify.mjs"

--- a/scripts/check-mq.mjs
+++ b/scripts/check-mq.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+/**
+ * Fails if a Media Queries Level 4 range query reaches the source or the build.
+ *
+ * `@media (width <= 620px)` reads better than `@media (max-width: 620px)` and
+ * means the same thing on any browser that understands it. On one that does
+ * not - iOS Safari before 16.4, March 2023 - the query fails to parse and the
+ * browser throws away the entire block. Every mobile breakpoint on this site
+ * was written in the range form, so those phones were served the desktop
+ * layout with no adaptation at all: rails beside content at 430px, label/value
+ * grids overprinting, sideways scroll. It shipped, and it took a real device to
+ * find, because every engine we test in supports the syntax.
+ *
+ * The same failure applies to `matchMedia('(width <= 620px)')`, which quietly
+ * returns matches:false forever, so the folds and swipe rows never engaged
+ * either.
+ *
+ * Checked in `src/` (what someone will edit) and in `dist/` (what actually
+ * ships, in case a transformer ever puts it back).
+ */
+import { readdirSync, readFileSync, statSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+/* Inside a media query only. A bare `r.width > 0` in TypeScript is arithmetic,
+   not a breakpoint, so the match has to be anchored to a length unit. */
+const RANGE = /\(\s*(?:width|height|inline-size|block-size)\s*[<>]=?\s*[\d.]+(?:px|em|rem)/i;
+
+const EXT = /\.(css|astro|tsx|ts|js|mjs|html)$/;
+const SKIP = new Set(['node_modules', '.git', '.astro']);
+
+function walk(dir, out = []) {
+  for (const name of readdirSync(dir)) {
+    if (SKIP.has(name)) continue;
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (EXT.test(name)) out.push(p);
+  }
+  return out;
+}
+
+const roots = ['src', 'dist'].filter((d) => existsSync(d));
+const bad = [];
+
+for (const root of roots) {
+  for (const file of walk(root)) {
+    /* Comments keep their line count so the report still points somewhere
+       real, but lose their content: the note explaining this rule quotes the
+       syntax it bans, and so will the next one. */
+    const text = readFileSync(file, 'utf8').replace(/\/\*[\s\S]*?\*\//g, (c) =>
+      c.replace(/[^\n]/g, ' '),
+    );
+    if (!RANGE.test(text)) continue;
+    text.split('\n').forEach((line, i) => {
+      /* Minified CSS is one long line, so report the query rather than the
+         column and let the source copy carry the line number. */
+      let m;
+      const all = new RegExp(RANGE.source, 'gi');
+      while ((m = all.exec(line))) bad.push(`${file}:${i + 1}  ${m[0]}...)`);
+    });
+  }
+}
+
+if (bad.length) {
+  console.error(
+    `\nRange-syntax media queries found (${bad.length}). These are dropped whole by\n` +
+      `iOS Safari before 16.4, which serves those phones an unstyled desktop layout.\n` +
+      `Write min-width:/max-width: instead - see the note at the top of global.css.\n`,
+  );
+  for (const b of bad) console.error(`  ${b}`);
+  process.exit(1);
+}
+
+console.log(`check-mq: no range-syntax media queries in ${roots.join(', ')}`);

--- a/src/components/react/AutoTyper.tsx
+++ b/src/components/react/AutoTyper.tsx
@@ -39,7 +39,7 @@ const LIMIT = 140;
 /* Where the two controls stop being worth 191px of a phone. Below it the card
    opens as its own finished output and one press, and the field, the slider and
    the presets arrive when a thumb asks for them. */
-const NARROW = '(width <= 620px)';
+const NARROW = '(max-width: 620px)';
 
 export default function AutoTyper() {
   const [source, setSource] = useState(PRESETS[0]?.[1] ?? '');

--- a/src/components/react/DeviationFrame.tsx
+++ b/src/components/react/DeviationFrame.tsx
@@ -46,7 +46,7 @@ const MIN = 0.5;
     is the same seed drawn whole at the card's width rather than half of one at
     half scale, and it does not pull Chart.js off a CDN to sample two thousand
     deviates on a handset. So down here the file waits to be asked. */
-const HANDSET = '(width <= 765px)';
+const HANDSET = '(max-width: 765px)';
 
 export default function DeviationFrame({ src, href, title, poster, posterAlt, note }: Props) {
   const [live, setLive] = useState(false);

--- a/src/scripts/deep.ts
+++ b/src/scripts/deep.ts
@@ -11,7 +11,7 @@
  * markup is a press that would do nothing there.
  */
 
-const NARROW = '(width <= 620px)';
+const NARROW = '(max-width: 620px)';
 
 function fold(deep: HTMLElement): void {
   deep.setAttribute('hidden', 'until-found');

--- a/src/scripts/ledger.ts
+++ b/src/scripts/ledger.ts
@@ -14,7 +14,7 @@
  * right way round for that failure to fall.
  */
 
-const NARROW = '(width <= 620px)';
+const NARROW = '(max-width: 620px)';
 
 /* The stack line is "job title · thing · thing", glued by the non-breaking
    separator `dots` puts in. Folded, the row wants the title and none of the

--- a/src/scripts/motion.ts
+++ b/src/scripts/motion.ts
@@ -266,7 +266,7 @@ function installNavPanel(): void {
 
   // Dragged wider than the breakpoint the toggle is gone, so anything left
   // open would be open with no way to shut it.
-  window.matchMedia('(width > 620px)').addEventListener('change', (e) => {
+  window.matchMedia('(min-width: 620.001px)').addEventListener('change', (e) => {
     if (e.matches) setOpen(false, false);
   });
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -8,6 +8,17 @@
 
    Mono is a label face here, not an annotation layer: kickers, badges,
    captions, and nothing else.
+
+   Every breakpoint is written `max-width:` / `min-width:`, never the Level 4
+   range form `(width <= 620px)`. The range form is nicer to read and it cost
+   us the entire mobile site: a browser that cannot parse a media query drops
+   the whole block, so on iOS Safari before 16.4 every one of these breakpoints
+   vanished and a phone was served the raw desktop layout - two-column rails at
+   430px, label/value grids printing on top of each other, the page scrolling
+   sideways. The same rule holds for `matchMedia` strings in TS, which fail the
+   same way and took the folds and the swipe rows down with them. Modernising
+   this back is a site-wide outage on older phones; `scripts/check-mq.mjs`
+   fails the build if it reappears.
    ═══════════════════════════════════════════════════════════════════════ */
 
 /* ── 1. TOKENS ───────────────────────────────────────────────────────── */
@@ -674,7 +685,7 @@ summary,
 
 /* Nothing can open it above the breakpoint, but a window dragged wider while
    it is open would otherwise leave it hanging there over the full-width row. */
-@media (width > 620px) {
+@media (min-width: 620.001px) {
   .nav__panel {
     display: none;
   }
@@ -831,7 +842,7 @@ summary,
    picture and does not move for the type; the type moves, and the same worst
    case reads 4.7. Above and below the band it is untouched, at 5.2 and better
    on the same measurement. */
-@media (width > 620px) and (width <= 900px) {
+@media (min-width: 620.001px) and (max-width: 900px) {
   .hero__intro {
     color: var(--on-ink-hi);
   }
@@ -3088,7 +3099,7 @@ summary,
 /* The split is worth having only while the wider column can still feed the
    frame the 665px it refuses to go below. Under that the row is costing the
    frame more than it saves the page, so it stops being a row. */
-@media (width <= 1260px) {
+@media (max-width: 1260px) {
   .labs {
     grid-template-columns: minmax(0, 1fr);
   }
@@ -3450,7 +3461,7 @@ summary,
    The component only ever folds below this width, so the query is a second
    lock rather than the condition: whatever the script does, the wide layout
    keeps every control it has. */
-@media (width <= 620px) {
+@media (max-width: 620px) {
   .stage--typer[data-fold] .typer {
     display: none;
   }
@@ -3595,7 +3606,7 @@ summary,
 /* Below this the card is narrower than half the document and the component
    stops shrinking, so the drawn height stops changing too. 765 is where the
    card crosses 665, measured rather than guessed. */
-@media (width <= 765px) {
+@media (max-width: 765px) {
   .devframe {
     aspect-ratio: auto;
     height: 298px;
@@ -3988,7 +3999,7 @@ button.toolbar__link {
 /* Under 900 the text column has stopped being a column: it is 240px of
    minimum next to an image that wants the rest, and the paragraph breaks
    every four words. Stack it and give the lead the whole measure. */
-@media (width <= 900px) {
+@media (max-width: 900px) {
   .rz {
     grid-template-columns: minmax(0, 1fr);
   }
@@ -4003,7 +4014,7 @@ button.toolbar__link {
    the argument the pair exists to make - same screen, one toggle apart - is
    the one thing a shot this small still carries, better adjacent than
    separated by a scroll. */
-@media (width <= 620px) {
+@media (max-width: 620px) {
   /* Sized for a 605px frame, and a third of the width of a 143px one. The
      type is already at the floor, so the room comes out of the padding. */
   .rz__theme {
@@ -4038,7 +4049,7 @@ button.toolbar__link {
   display: contents;
 }
 
-@media (width <= 620px) {
+@media (max-width: 620px) {
   .swipe {
     position: relative;
     display: block;
@@ -4748,7 +4759,7 @@ span.buoy__p {
   text-underline-offset: 3px;
 }
 
-@media (width <= 620px) {
+@media (max-width: 620px) {
   .ins__d > div {
     grid-template-columns: minmax(0, 1fr);
     gap: 0;
@@ -4882,7 +4893,7 @@ span.buoy__p {
 }
 
 /* ── 16. BREAKPOINTS ─────────────────────────────────────────────────── */
-@media (width <= 1000px) {
+@media (max-width: 1000px) {
   .fs,
   .card__cols,
   .card--full .card__cols,
@@ -4891,7 +4902,7 @@ span.buoy__p {
   }
 }
 
-@media (width <= 900px) {
+@media (max-width: 900px) {
   .hero__bottom,
   .about,
   .log,
@@ -4952,7 +4963,7 @@ span.buoy__p {
   }
 }
 
-@media (width <= 620px) {
+@media (max-width: 620px) {
   :root {
     --pad: 1rem;
   }
@@ -5354,7 +5365,7 @@ span.buoy__p {
    and both take the full width - the same shape the about-page facts use for
    the same reason. Costs about 130px of page and buys back a readable
    measure, which on the one device that is all measure is the better trade. */
-@media (width <= 470px) {
+@media (max-width: 470px) {
   .skim > div {
     grid-template-columns: 1fr;
     gap: 0.1rem;


### PR DESCRIPTION
## Summary

Every breakpoint on the site was written in Media Queries Level 4 range syntax - `@media (width <= 620px)`. A browser that cannot parse a media query drops the entire block, and iOS Safari only learned this syntax in 16.4 (March 2023). Phones older than that were served the desktop layout with no mobile adaptation at all.

A device report on a ~430px iPhone listed six separate symptoms: the Experience rail rendering beside its content, role text wrapping at ~12 characters, education degrees printing on top of each other, wind-tunnel technical notes overprinting, model skims as one-word-per-line columns, and the page scrolling sideways. All six are the same cause.

Five `matchMedia` strings in TypeScript had the same defect, where they return `matches: false` forever. So those phones also lost every mobile mechanism on the page - the card folds, the work ledger, the swipe rows - while still paying the full content cost.

This is a mechanical syntax rewrite with no design change. It is deliberately separate from the mobile polish work that follows it, so it can ship on its own.

## Changes

- `src/styles/global.css` - 13 media queries rewritten to `min-width:` / `max-width:`. `max-width: N` is exactly equivalent to `width <= N`; the two `width > 620px` queries become `min-width: 620.001px`. A note at the top of the file records why the modern form is banned here.
- `src/scripts/motion.ts`, `src/scripts/deep.ts`, `src/scripts/ledger.ts`, `src/components/react/AutoTyper.tsx`, `src/components/react/DeviationFrame.tsx` - the five `matchMedia` query strings, same rewrite.
- `scripts/check-mq.mjs` - new guard that fails if range syntax reaches `src/` or `dist/`. Wired into both `build` and `lint`. It strips comments first, so the note explaining the rule can quote the syntax it bans.

## Output

**Reproduction.** Deleting the 13 range blocks from the shipped stylesheet at 430px - which is what a non-supporting browser does - reproduces each reported symptom exactly:

```
scrollWidth 444 / client 430  (overflow 14)
  #about     div.head        2 cols  [140 + 223]     rail beside its content
  #work      li.role         2 cols  [138 + 90]      role text at ~12 chars/line
  #education dl.edu__deg     4 cols  [42 x 4]        degrees overprinting
  #building  dl.specs        2 cols  [84 + 84]       technical notes overprinting
  #building  div.card__cols  2 cols  [150 + 184]     skinny model skims
```

**Same probe after the fix** - nothing is left for a non-supporting browser to discard, which makes this engine-independent:

```
[dropped 0 range-syntax media blocks]
scrollWidth 430 / client 430  (overflow 0)
```

**Real WebKit 26.0**, at both phone widths:

```
                390        430
overflow        0          0
#about .head    358px      398px     (single column)
#work .role     358px      398px     (single column)
.edu__deg       322px      362px     (single column)
nav__links      none       none      (disclosure engaged)
.swipe__row     flex       flex      (swipe rows engaged)
```

**Desktop unchanged.** Full-page 1440 capture, 2880x25308, against a build of the current `master`:

| diff | differing px | worst channel delta | y range |
|---|---|---|---|
| master vs this branch | 830,864 | 5 | 0 - 1,556 |
| master vs **itself** | 1,611,567 | 210 | 0 - 17,681 |

The hero canvas does not render deterministically, so the second row is the control: the same build captured twice differs by nearly twice as many pixels, a 42x larger channel delta, and over 11x the vertical range. This change is smaller than the engine's own run-to-run noise.

**Guard.** `check-mq` passes on a clean tree and catches a planted violation:

```
check-mq: no range-syntax media queries in src, dist
...
Range-syntax media queries found (1).
  src/styles/_mqtest.css:1  (width <= 500px...)
```

`npm run lint` and `npm run build` both green.
