### PR TITLE
[site] Rebuild the phone layout for the 360-440 band

### DIFF
--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -991,6 +991,87 @@ for (const width of [390, 430, 620]) {
   );
 }
 
+/* ── the wordmark's turn ─────────────────────────────────────────────────
+   Scroll-linked, so both ways it can go wrong are silent. It can stop agreeing
+   with the stylesheet at the top of the page, which is a change to the poster
+   and the one thing this was not allowed to touch. And it can turn the wrong
+   way: the rotation is mostly about Y, so deepening it foreshortens the block
+   and flattening it un-foreshortens it, which grows "UPPAL" toward an edge a
+   phone does not have to spare. Down is the only direction with no overflow
+   in it, and this is what keeps it pointing down. */
+for (const width of [430, 1440]) {
+  const phone = width < 700;
+  await run(
+    `wordmark ${width}`,
+    {
+      viewport: { width, height: phone ? 932 : 900 },
+      deviceScaleFactor: 2,
+      isMobile: phone,
+      hasTouch: phone,
+    },
+    async (page) => {
+      await settle(page);
+      const m = await page.evaluate(async () => {
+        const h1 = document.querySelector('.hero h1');
+        let top = 0;
+        for (let n = h1; n; n = n.offsetParent) top += n.offsetTop;
+        const end = top + h1.offsetHeight;
+
+        /* Instant, because the document scrolls smoothly and a smooth scroll
+           is still on its way three frames later - which reads as a driver
+           that never moved. Two frames after it lands, because the driver
+           coalesces into one rAF and the box is read after the browser has
+           drawn what it wrote. */
+        const at = async (y) => {
+          window.scrollTo({ top: y, behavior: 'instant' });
+          await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+          const b = h1.getBoundingClientRect();
+          return { w: +b.width.toFixed(1), right: +b.right.toFixed(1) };
+        };
+
+        const rest = await at(0);
+        const live = getComputedStyle(h1).transform;
+        /* What the stylesheet alone would have drawn, asked of the same
+           element rather than compared against a matrix copied into this
+           file, which would be a second place the angle lives. */
+        const inline = h1.style.transform;
+        h1.style.removeProperty('transform');
+        const stylesheet = getComputedStyle(h1).transform;
+        h1.style.transform = inline;
+
+        const mid = await at(Math.round(end / 2));
+        const far = await at(end);
+        window.scrollTo({ top: 0, behavior: 'instant' });
+        return {
+          rest,
+          mid,
+          far,
+          live,
+          stylesheet,
+          end,
+          vw: document.documentElement.clientWidth,
+        };
+      });
+
+      note(
+        m.live === m.stylesheet,
+        `${width} the poster is untouched at the top of the page`,
+        `driver ${m.live.slice(0, 40)} vs stylesheet ${m.stylesheet.slice(0, 40)}`,
+      );
+      note(
+        m.rest.w > m.mid.w && m.mid.w > m.far.w,
+        `${width} the turn deepens on the way out, never flattens`,
+        `${m.rest.w} -> ${m.mid.w} -> ${m.far.w} over ${m.end}px of scroll`,
+      );
+      note(
+        m.rest.right <= m.vw && m.mid.right <= m.vw && m.far.right <= m.vw,
+        `${width} and never reaches the right edge doing it`,
+        `${m.rest.right} / ${m.mid.right} / ${m.far.right} vs ${m.vw}`,
+      );
+    },
+  );
+}
+
 /* ── 1440, prefers-reduced-motion: reduce ────────────────────────────── */
 await run(
   'reduced-motion',
@@ -1017,6 +1098,28 @@ await run(
           .slice(0, 6),
       };
     });
+    /* The wordmark's turn is the one piece of motion on this page tied to the
+       scroll rather than to a moment, so "no motion" has to mean it never
+       writes an angle at all - not that it writes a slower one. Scrolled and
+       asked again, because installing nothing and stopping after the first
+       frame look identical from the top of the page. */
+    const still = await page.evaluate(async () => {
+      const h1 = document.querySelector('.hero h1');
+      const seen = new Set();
+      for (const y of [0, 200, 600]) {
+        window.scrollTo({ top: y, behavior: 'instant' });
+        await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+        seen.add(getComputedStyle(h1).transform);
+      }
+      window.scrollTo({ top: 0, behavior: 'instant' });
+      return { angles: seen.size, inline: h1.style.transform };
+    });
+    note(
+      still.angles === 1 && still.inline === '',
+      'the wordmark holds the static tilt at every scroll position',
+      `${still.angles} angles, inline "${still.inline}"`,
+    );
+
     note(m.q, 'reduced-motion is actually on', '');
     note(m.btnTransition === '0.001s', 'transitions clamped to 1ms', m.btnTransition);
     note(m.caretHidden, 'the typer caret stops blinking', '');

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -1072,6 +1072,102 @@ for (const width of [430, 1440]) {
   );
 }
 
+/* ── the name swap ───────────────────────────────────────────────────────
+   Five letters replace a two-letter first line with a five-letter one, on the
+   one element on the page that is turned in three dimensions and sized off the
+   viewport. The failure it is worth checking for is geometric: a longer name
+   reaching an edge the short one never did, or the turn coming off the line
+   while its text is being rewritten. Then back, exactly, because an egg that
+   does not put the page down is a bug with a bow on it. */
+for (const width of [390, 430, 1440]) {
+  const phone = width < 700;
+  await run(
+    `name swap ${width}`,
+    {
+      viewport: { width, height: phone ? 932 : 900 },
+      deviceScaleFactor: 2,
+      isMobile: phone,
+      hasTouch: phone,
+    },
+    async (page) => {
+      await settle(page);
+
+      const read = () =>
+        page.evaluate(() => {
+          const h1 = document.querySelector('.hero h1');
+          const cta = document.querySelector('.hero__btns .btn');
+          /* The ink, not the box: the h1 is a full-width block whose own edges
+             say nothing about how far the letters reach. */
+          const ink = (el) => {
+            const r = document.createRange();
+            r.selectNodeContents(el);
+            const b = r.getBoundingClientRect();
+            r.detach();
+            return +b.right.toFixed(1);
+          };
+          return {
+            name: h1.querySelector('span:first-child').textContent,
+            out: h1.querySelector('.out').textContent,
+            label: cta.textContent,
+            href: cta.getAttribute('href'),
+            target: cta.getAttribute('target'),
+            rel: cta.getAttribute('rel'),
+            tilt: getComputedStyle(h1).transform,
+            outTilt: getComputedStyle(h1.querySelector('.out')).transform,
+            reach: Math.max(
+              ink(h1.querySelector('span:first-child')),
+              ink(h1.querySelector('.out')),
+            ),
+            docW: document.documentElement.scrollWidth,
+            vw: document.documentElement.clientWidth,
+            h: Math.round(h1.getBoundingClientRect().height),
+          };
+        });
+
+      const before = await read();
+      await page.keyboard.type('sonia');
+      await page.waitForTimeout(120);
+      const on = await read();
+      await page.keyboard.type('sonia');
+      await page.waitForTimeout(120);
+      const off = await read();
+
+      note(
+        on.name === 'Sonia' && on.out === before.out,
+        `${width} five letters and the wordmark reads Sonia Uppal`,
+        `${on.name} ${on.out}`,
+      );
+      note(
+        on.label === 'Sonia’s LinkedIn' &&
+          on.href === 'https://www.linkedin.com/in/soniau/' &&
+          on.target === '_blank' &&
+          (on.rel ?? '').includes('noopener'),
+        `${width} and the one action goes to her profile`,
+        `${on.label} -> ${on.href} ${on.target} ${on.rel}`,
+      );
+      note(
+        on.tilt === before.tilt && on.outTilt === before.outTilt && on.h === before.h,
+        `${width} the turn and the line box are the same as before it`,
+        `${on.tilt.slice(0, 40)} / ${on.h}px vs ${before.h}px`,
+      );
+      note(
+        on.reach <= on.vw && on.docW <= on.vw,
+        `${width} the longer name stays inside the viewport`,
+        `ink ${on.reach}, document ${on.docW}, viewport ${on.vw}`,
+      );
+      note(
+        off.name === before.name &&
+          off.label === before.label &&
+          off.href === before.href &&
+          off.target === null &&
+          off.rel === null,
+        `${width} typing it again hands the page back whole`,
+        `${off.name} / ${off.label} -> ${off.href} ${off.target} ${off.rel}`,
+      );
+    },
+  );
+}
+
 /* ── 1440, prefers-reduced-motion: reduce ────────────────────────────── */
 await run(
   'reduced-motion',

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -896,6 +896,101 @@ await run(
   },
 );
 
+/* ── the phone band ──────────────────────────────────────────────────────
+   390 is one phone. The device report that opened batch 10 came from a 430,
+   and everything it found had gone untested because 390 was the only width
+   anyone measured. So the band is checked at both ends and at the boundary,
+   and the three things that broke are the three things asserted: nothing
+   escapes the viewport, no section sits a rail beside its content, and no two
+   halves of a label/value pair are ever painted on top of each other. */
+for (const width of [390, 430, 620]) {
+  await run(
+    `phone band ${width}`,
+    { viewport: { width, height: 844 }, deviceScaleFactor: 2, isMobile: true, hasTouch: true },
+    async (page) => {
+      await settle(page);
+      const m = await page.evaluate(() => {
+        const de = document.documentElement;
+        const wide = [];
+        for (const e of document.querySelectorAll('body *')) {
+          const b = e.getBoundingClientRect();
+          if (b.width === 0) continue;
+          /* Wider than the viewport on purpose, under its own overflow: the
+             frame switcher, the swipe row, and the 2015 file at a size it will
+             not bend. */
+          if (e.closest('.fs__scroll, .swipe__row, .devframe, .asm__loupe')) continue;
+          if (b.right > de.clientWidth + 0.5 || b.left < -0.5)
+            wide.push(`${e.tagName}.${e.className}`.trim().slice(0, 48));
+        }
+
+        /* A rail is a grid whose first track is a fraction of its second. One
+           track means it collapsed; the numeral gutters (.fact, .vitals) are
+           two-track by design and are named rather than inferred. */
+        const rails = [];
+        for (const sel of ['.head', '.about', '.card__hero', '.card__cols', '.role', '.skg']) {
+          for (const e of document.querySelectorAll(sel)) {
+            if (!e.getBoundingClientRect().width) continue;
+            const tracks = getComputedStyle(e).gridTemplateColumns.split(/\s+/).length;
+            if (tracks > 1) rails.push(`${sel} -> ${getComputedStyle(e).gridTemplateColumns}`);
+          }
+        }
+
+        /* The label/value component, everywhere it is used. Two boxes from one
+           dl sharing pixels is the failure the device report led with. */
+        const hits = [];
+        for (const dl of document.querySelectorAll('dl')) {
+          const kids = [...dl.querySelectorAll('dt, dd')].filter(
+            (e) => e.getBoundingClientRect().width > 0,
+          );
+          for (let i = 0; i < kids.length; i++)
+            for (let j = i + 1; j < kids.length; j++) {
+              const A = kids[i].getBoundingClientRect();
+              const B = kids[j].getBoundingClientRect();
+              const ox = Math.min(A.right, B.right) - Math.max(A.left, B.left);
+              const oy = Math.min(A.bottom, B.bottom) - Math.max(A.top, B.top);
+              if (ox > 1 && oy > 1)
+                hits.push(
+                  `${dl.className || 'dl'}: "${kids[i].textContent.trim().slice(0, 18)}" x "${kids[j].textContent.trim().slice(0, 18)}"`,
+                );
+            }
+        }
+
+        return {
+          docW: de.scrollWidth,
+          clientW: de.clientWidth,
+          height: de.scrollHeight,
+          wide: [...new Set(wide)].slice(0, 6),
+          rails: [...new Set(rails)].slice(0, 6),
+          hits: [...new Set(hits)].slice(0, 6),
+        };
+      });
+
+      note(
+        m.docW <= m.clientW,
+        `${width} the document is no wider than the viewport`,
+        `scrollWidth ${m.docW} vs ${m.clientW}`,
+      );
+      note(m.wide.length === 0, `${width} nothing escapes the viewport`, m.wide.join(', '));
+      note(
+        m.rails.length === 0,
+        `${width} no section sits a rail beside its content`,
+        m.rails.join(' | '),
+      );
+      note(
+        m.hits.length === 0,
+        `${width} no label prints on top of its neighbour`,
+        m.hits.join(' | '),
+      );
+      console.log(`       page height ${m.height}px at ${width}`);
+
+      if (width === 430) {
+        await page.screenshot({ path: `${OUT}/full-430.png`, fullPage: true });
+        console.log(`       wrote ${OUT}/full-430.png`);
+      }
+    },
+  );
+}
+
 /* ── 1440, prefers-reduced-motion: reduce ────────────────────────────── */
 await run(
   'reduced-motion',

--- a/src/data/content.ts
+++ b/src/data/content.ts
@@ -757,7 +757,9 @@ export const earlier = [
 
 export const skills = [
   { group: 'Languages', items: ['Python', 'TypeScript', 'JavaScript', 'SQL', 'C'] },
-  { group: 'Frontend', items: ['React', 'Redux', 'three.js / WebGL', 'HTML / CSS', 'PWAs'] },
+  /* The two renderers sit together: one is the library saltline draws with,
+     the other is the standard it draws against. */
+  { group: 'Frontend', items: ['React', 'three.js / WebGL', 'babylon.js', 'HTML / CSS', 'PWAs'] },
   {
     group: 'Backend',
     items: [
@@ -767,16 +769,18 @@ export const skills = [
       'PostgreSQL',
       'BigQuery',
       'Socket.io',
+      /* A room server is a real-time transport with opinions, so it files with
+         the transports rather than with the runtimes. */
+      'colyseus.js',
       /* Telephony sits with the other real-time transports rather than with the
          hosted platforms: what he owns is the call routing, not the account. */
       'Twilio / SIP',
       'Temporal',
-      'Microservices',
     ],
   },
   {
     group: 'Infrastructure',
-    items: ['GCP', 'Kubernetes', 'Terraform', 'Fly.io', 'AWS', 'Linux', 'CI/CD'],
+    items: ['GCP', 'Kubernetes', 'Helm', 'Terraform', 'Fly.io', 'AWS', 'CI/CD'],
   },
   {
     group: 'Data and scientific',
@@ -793,7 +797,7 @@ export const skills = [
  * is not evidence: Ember Wilds is live multiplayer and names no transport, so
  * Socket.io does not get to claim it.
  *
- * Four skills have nothing that clears that bar. They are on the resume and
+ * Five skills have nothing that clears that bar. They are on the resume and
  * they stay in the list, with an empty array, and the page says so rather than
  * borrowing something that nearly fits. Every skill needs a key here, so a
  * genuine blank can never be confused with one that was forgotten - the page
@@ -811,10 +815,13 @@ export const evidence = {
   C: ['baaqmd', 'pickle'],
 
   React: ['elderwood', 'notable', 'harvest', 'umassDev', 'arena', 'rendezvous'],
-  Redux: ['rendezvous'],
   /* saltline's renderer is Babylon.js, which is WebGL - a fact about the
      library, not a claim about the work, and the notes name the library. */
   'three.js / WebGL': ['saltline', 'elderwood', 'grinch'],
+  /* The same row of saltline's technical notes, read for what it actually
+     says rather than for the standard underneath it: "Renderer, Babylon.js on
+     Fly.io". This is the one of the three additions the page can back up. */
+  'babylon.js': ['saltline'],
   /* The three demos are hand-written HTML files still served at their own
      URLs. Every other project is a browser app that never says so. */
   'HTML / CSS': ['autotyper', 'deviation', 'grinch'],
@@ -826,17 +833,22 @@ export const evidence = {
   PostgreSQL: ['notable', 'harvest', 'umassDev', 'rendezvous'],
   BigQuery: ['notable'],
   'Socket.io': [],
+  /* Ember Wilds is the room server this would be evidence for, and its card
+     names no transport - the same reason Socket.io claims nothing. Naming one
+     in the notes to earn the chip would be writing the evidence to fit. */
+  'colyseus.js': [],
   'Twilio / SIP': ['notable'],
   Temporal: [],
-  /* Both of these say the word in their own description of the job. */
-  Microservices: ['harvest', 'gotit'],
 
   GCP: ['notable', 'arena', 'rendezvous'],
   Kubernetes: ['notable'],
+  /* The current role's deploy tooling is named as deploy tooling. Kubernetes
+     is on the page by name and Helm is not, and standing next to something
+     that is named is not the same as being named. */
+  Helm: [],
   Terraform: ['notable'],
   'Fly.io': ['saltline', 'ember'],
   AWS: [],
-  Linux: [],
   /* "Deploy tooling", in the first bullet of the current role. */
   'CI/CD': ['notable'],
 

--- a/src/data/content.ts
+++ b/src/data/content.ts
@@ -317,6 +317,11 @@ export const ember = {
     ['Status', 'Live, no install'],
     ['Shape', 'Web tier plus realm service'],
     ['Realm cap', '64 players in one realm'],
+    /* The two rows the skills index points at. A chip that says a technology
+       turns up here has to land on a card that names it, so the card names it
+       rather than the index asking to be believed. */
+    ['Transport', 'Colyseus rooms over WebSocket'],
+    ['Renderer', 'three.js in the browser tab'],
     ['Host', 'Fly.io'],
     ['World', 'Seven regions, harder as you travel outward'],
     ['Classes', 'Unlocked by beast lore and study, not a skill tree'],
@@ -437,6 +442,7 @@ export const saltline = {
     /* The 20 is read off the server, not off the HUD: a room holds 40 boats and
        the NPC fleet is capped at 20, so 20 hulls are left for people. */
     ['Multiplayer', 'Live, sail together, up to 20 players a sea'],
+    ['Transport', 'Colyseus rooms over WebSocket'],
     ['Model', 'Point of sail sets thrust; thrust and heading set VMG'],
     ['Luffing', 'Point too close to the wind and you stop'],
     ['HUD', 'Relative wind, heel angle, thrust percent, VMG in knots'],
@@ -794,10 +800,17 @@ export const skills = [
  * One rule decides every entry. A place counts only if the reader can confirm
  * it without taking my word for anything - a stack line under a job, a row in
  * a project's technical notes, or a demo that runs a few sections up. Adjacent
- * is not evidence: Ember Wilds is live multiplayer and names no transport, so
- * Socket.io does not get to claim it.
+ * is not evidence: both room servers name Colyseus as their transport, and
+ * naming one transport is exactly what stops Socket.io claiming them.
  *
- * Five skills have nothing that clears that bar. They are on the resume and
+ * The rule runs the other way too. When a chip is true of a project and the
+ * card says nothing about it, the fix is the card, not the index - a reference
+ * that lands somewhere the reader cannot see the thing is a dead promise, and
+ * an index full of those is worth less than no index. Ember Wilds and saltline
+ * each gained a technical note this way, and each note is a fact about the
+ * build that was already true.
+ *
+ * Four skills have nothing that clears that bar. They are on the resume and
  * they stay in the list, with an empty array, and the page says so rather than
  * borrowing something that nearly fits. Every skill needs a key here, so a
  * genuine blank can never be confused with one that was forgotten - the page
@@ -815,12 +828,12 @@ export const evidence = {
   C: ['baaqmd', 'pickle'],
 
   React: ['elderwood', 'notable', 'harvest', 'umassDev', 'arena', 'rendezvous'],
-  /* saltline's renderer is Babylon.js, which is WebGL - a fact about the
-     library, not a claim about the work, and the notes name the library. */
-  'three.js / WebGL': ['saltline', 'elderwood', 'grinch'],
-  /* The same row of saltline's technical notes, read for what it actually
-     says rather than for the standard underneath it: "Renderer, Babylon.js on
-     Fly.io". This is the one of the three additions the page can back up. */
+  /* Three cards name three.js in their own notes. saltline is not one of them
+     and does not belong here: its renderer is Babylon, which is WebGL, and the
+     chip next door is the one that says so. */
+  'three.js / WebGL': ['elderwood', 'ember', 'grinch'],
+  /* One row of saltline's technical notes, read for what it says rather than
+     for the standard underneath it: "Renderer, Babylon.js on Fly.io". */
   'babylon.js': ['saltline'],
   /* The three demos are hand-written HTML files still served at their own
      URLs. Every other project is a browser app that never says so. */
@@ -833,10 +846,9 @@ export const evidence = {
   PostgreSQL: ['notable', 'harvest', 'umassDev', 'rendezvous'],
   BigQuery: ['notable'],
   'Socket.io': [],
-  /* Ember Wilds is the room server this would be evidence for, and its card
-     names no transport - the same reason Socket.io claims nothing. Naming one
-     in the notes to earn the chip would be writing the evidence to fit. */
-  'colyseus.js': [],
+  /* Both room servers run on Colyseus, and both cards now say which transport
+     they run on - which is also why Socket.io above still claims nothing. */
+  'colyseus.js': ['saltline', 'ember'],
   'Twilio / SIP': ['notable'],
   Temporal: [],
 

--- a/src/scripts/motion.ts
+++ b/src/scripts/motion.ts
@@ -3,6 +3,7 @@ import { installDeep } from './deep';
 import { installLedger } from './ledger';
 import { installSwipe } from './swipe';
 import { installTunnel } from './tunnel';
+import { installWordmark } from './wordmark';
 import { springKeyframes } from './spring';
 import { installHero } from '../heroes/runtime';
 /* Type only, so the chunk itself still arrives on the tenth key and not before. */
@@ -504,6 +505,7 @@ installLongTab();
 installReceipts();
 installKonami();
 installHeroCanvas();
+installWordmark();
 installAssembly();
 installTunnel();
 installSwipe();

--- a/src/scripts/motion.ts
+++ b/src/scripts/motion.ts
@@ -6,8 +6,6 @@ import { installTunnel } from './tunnel';
 import { installWordmark } from './wordmark';
 import { springKeyframes } from './spring';
 import { installHero } from '../heroes/runtime';
-/* Type only, so the chunk itself still arrives on the tenth key and not before. */
-import type * as gravity from './gravity';
 
 /**
  * Page-level behaviour. Four things: reveal on first sight, the nav's current
@@ -425,19 +423,19 @@ function installReceipts(): void {
   btn.addEventListener('click', () => apply(!root.classList.contains('receipts')));
 }
 
-/* ── Ten keys ────────────────────────────────────────────────────────── */
+/* ── Typed sequences ─────────────────────────────────────────────────── */
 /**
- * The one thing on this page that is not explained anywhere on it.
+ * The two things on this page that are not explained anywhere on it.
  *
- * What it does lives in its own module and is fetched once the first four keys
- * are in, so a page that is only ever read carries this listener and nothing
- * else, and a page that is not only read has the code in hand by the time the
- * tenth key lands rather than waiting on a request for it.
+ * What each one does lives in its own module and is fetched once a prefix of
+ * its code is in, so a page that is only ever read carries these listeners and
+ * nothing else, and a page that is not only read has the code in hand by the
+ * time the last key lands rather than waiting on a request for it.
  *
- * The arrow keys already do two things here - they scroll, and they move the
- * light around the hero when the canvas has focus - and both keep doing them.
- * Nothing is swallowed on the way past; entering this is meant to look like
- * nothing until it is not.
+ * Nothing is swallowed on the way past. The arrow keys already do two things
+ * here - they scroll, and they move the light around the hero when the canvas
+ * has focus - and both keep doing them while the code is being entered. Typing
+ * either of these is meant to look like nothing until it is not.
  */
 const KONAMI = [
   'arrowup',
@@ -452,15 +450,27 @@ const KONAMI = [
   'a',
 ];
 
-function installKonami(): void {
+const SONIA = ['s', 'o', 'n', 'i', 'a'];
+
+/**
+ * A hidden key sequence. `warmAt` is how much of the code has to be in before
+ * the payload is worth fetching, and `allowed` is asked at the end rather than
+ * at the start so a refused egg is still a silent one.
+ */
+function installSequence(
+  code: string[],
+  warmAt: number,
+  load: () => Promise<() => void>,
+  allowed: () => boolean = () => true,
+): void {
   const seen: string[] = [];
-  let warm: Promise<typeof gravity> | null = null;
+  let warm: Promise<() => void> | null = null;
 
   /* The trailing n keys against the first n of the code, so a false start on a
      repeated key - up, up, up - carries the match it has rather than dropping
      to nothing and needing the whole thing typed again. */
   const ran = (n: number): boolean =>
-    seen.length >= n && KONAMI.slice(0, n).every((k, i) => k === seen[seen.length - n + i]);
+    seen.length >= n && code.slice(0, n).every((k, i) => k === seen[seen.length - n + i]);
 
   document.addEventListener('keydown', (e) => {
     const on = document.activeElement as HTMLElement | null;
@@ -478,17 +488,28 @@ function installKonami(): void {
     }
 
     seen.push(e.key.toLowerCase());
-    if (seen.length > KONAMI.length) seen.shift();
+    if (seen.length > code.length) seen.shift();
 
-    if (!warm && ran(4)) warm = import('./gravity');
-    if (!ran(KONAMI.length)) return;
+    if (!warm && ran(warmAt)) warm = load();
+    if (!ran(code.length)) return;
 
     seen.length = 0;
-    // Flying text is the exact thing that setting is asking not to happen, so
-    // under it there is no egg at all rather than a still one.
-    if (reduced.matches) return;
-    void (warm ?? import('./gravity')).then((m) => m.drop());
+    if (!allowed()) return;
+    void (warm ?? load()).then((run) => run());
   });
+}
+
+function installEggs(): void {
+  // Flying text is the exact thing that setting is asking not to happen, so
+  // under it there is no egg at all rather than a still one.
+  installSequence(
+    KONAMI,
+    4,
+    () => import('./gravity').then((m) => m.drop),
+    () => !reduced.matches,
+  );
+  /* The name swap moves nothing, so it is the same egg under either setting. */
+  installSequence(SONIA, 3, () => import('./sonia').then((m) => m.toggle));
 }
 
 /* ── Hero ────────────────────────────────────────────────────────────── */
@@ -503,7 +524,7 @@ installNavPanel();
 installThemeColor();
 installLongTab();
 installReceipts();
-installKonami();
+installEggs();
 installHeroCanvas();
 installWordmark();
 installAssembly();

--- a/src/scripts/sonia.ts
+++ b/src/scripts/sonia.ts
@@ -1,0 +1,53 @@
+/**
+ * Sonia Uppal.
+ *
+ * Five letters typed anywhere on the page and the poster is hers: the wordmark
+ * reads Sonia Uppal, and the one action in the hero goes to her LinkedIn
+ * instead of down the page. Typing them again hands it back, and so does a
+ * reload - nothing is written down, nothing is sent anywhere, and there is no
+ * control on the page that does this.
+ *
+ * Both lines keep their own tilt and the h1 keeps its box: the second line is
+ * already the wider of the two at every width, so a five-letter first line
+ * changes what the poster says without changing where any of it is. That is
+ * why this is a text swap and not a layout, and why the scroll driver in
+ * `wordmark.ts` never has to hear about it.
+ */
+
+const NAME = 'Sonia';
+const LABEL = 'Sonia’s LinkedIn';
+const HREF = 'https://www.linkedin.com/in/soniau/';
+
+/* What the page said before, held for exactly as long as it is not saying it.
+   Null is the whole of the off state, so a reload is a restore. */
+let held: { name: string; label: string; href: string } | null = null;
+
+export function toggle(): void {
+  const name = document.querySelector<HTMLElement>('.hero h1 span:first-child');
+  const cta = document.querySelector<HTMLAnchorElement>('.hero__btns .btn');
+  if (!name || !cta) return;
+
+  if (held) {
+    name.textContent = held.name;
+    cta.textContent = held.label;
+    cta.setAttribute('href', held.href);
+    /* An in-page jump that opens a tab is a bug, so the two attributes the
+       outbound link needed come off with it. */
+    cta.removeAttribute('target');
+    cta.removeAttribute('rel');
+    held = null;
+    return;
+  }
+
+  held = {
+    name: name.textContent ?? '',
+    label: cta.textContent ?? '',
+    href: cta.getAttribute('href') ?? '',
+  };
+
+  name.textContent = NAME;
+  cta.textContent = LABEL;
+  cta.setAttribute('href', HREF);
+  cta.setAttribute('target', '_blank');
+  cta.setAttribute('rel', 'noopener');
+}

--- a/src/scripts/wordmark.ts
+++ b/src/scripts/wordmark.ts
@@ -1,0 +1,135 @@
+/**
+ * The wordmark keeps turning as the reader leaves it.
+ *
+ * The hero is a poster held at an angle, and at the top of the page it is
+ * exactly the angle the stylesheet sets - nothing here moves until the reader
+ * does. Scrolling deepens the turn, so the two lines fall further away as they
+ * go up out of the frame and the hero reads as a plane the page is sliding off
+ * rather than a picture that happens to scroll. The turn finishes as the
+ * wordmark's last pixel crosses the top edge, so all of the motion happens
+ * while there is something to look at.
+ *
+ * Deeper rather than flatter, and this is not a taste call. The rotation is
+ * mostly about Y, so a deeper angle foreshortens the block and a shallower one
+ * un-foreshortens it: resolving the tilt toward zero grows "UPPAL" past the
+ * width it was sized to fit, and at 1440 that is 150px of it. Handing a phone
+ * back the sideways scroll this batch exists to remove, for a decoration, is
+ * not a trade. Down is the direction that cannot overflow.
+ *
+ * ── why a scroll listener and not `animation-timeline: scroll()`
+ *
+ * The CSS timeline is the better mechanism: it runs off the main thread and
+ * costs nothing at all. It also wants Safari 26, and the phone that opened this
+ * batch is a Safari that cannot parse a media query range - many versions under
+ * that. Writing both means keeping a keyframe block and a driver agreeing about
+ * one curve so that the engines which least need the help get the cheaper path.
+ * Measured at 4x CPU against the same build with this file unwired, the driver
+ * costs 0.3ms per frame at 430 and 0.05ms at 1440, on frames that already take
+ * 26 and 84. The second implementation costs more than it saves.
+ *
+ * Nothing here is a scroll effect in the hijacking sense. The page scrolls at
+ * exactly the speed it is pushed; only the angle of one element is a function
+ * of where it got to.
+ */
+
+/* Both lines turn, and each one reads its own pair of angles off the
+   stylesheet. The wrapper carries the axis for both: the axis is what makes
+   the two turns the same turn. */
+interface Turn {
+  el: HTMLElement;
+  axis: string;
+  from: number;
+  span: number;
+}
+
+const angle = (cs: CSSStyleDeclaration, name: string): number =>
+  parseFloat(cs.getPropertyValue(name));
+
+export function installWordmark(): void {
+  const h1 = document.querySelector<HTMLElement>('.hero h1');
+  if (!h1) return;
+
+  const axis = getComputedStyle(h1).getPropertyValue('--axis').trim();
+  if (!axis) return;
+
+  const turns: Turn[] = [];
+  for (const el of [h1, ...h1.querySelectorAll<HTMLElement>('.out')]) {
+    const cs = getComputedStyle(el);
+    const from = angle(cs, '--tilt');
+    const to = angle(cs, '--far');
+    /* A line with no `--far` of its own is one the stylesheet did not ask to
+       move, and it keeps whatever it was given. */
+    if (!Number.isFinite(from) || !Number.isFinite(to)) continue;
+    turns.push({ el, axis, from, span: to - from });
+  }
+  if (!turns.length) return;
+
+  const reduced = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+  /* The scroll distance the turn is spread over: the document position of the
+     wordmark's own bottom edge, so the angle lands at `--far` on the frame the
+     last of it leaves. Offsets rather than a client rect, because a client rect
+     is the turned box - measuring it mid-scroll would read a box the turn had
+     already shrunk and shorten the run it is being measured for. */
+  let end = 1;
+  const measure = (): void => {
+    let top = 0;
+    for (let n: HTMLElement | null = h1; n; n = n.offsetParent as HTMLElement | null) {
+      top += n.offsetTop;
+    }
+    end = Math.max(1, top + h1.offsetHeight);
+  };
+
+  let ticking = false;
+  const paint = (): void => {
+    ticking = false;
+    /* The only read, and it is a scalar the browser keeps to hand. Everything
+       after it is a write, so a frame here is style and composite with no
+       layout in between. */
+    const t = Math.min(1, Math.max(0, window.scrollY / end));
+    for (const turn of turns) {
+      turn.el.style.transform = `rotate3d(${turn.axis}, ${(turn.from + turn.span * t).toFixed(2)}deg)`;
+    }
+  };
+
+  const tick = (): void => {
+    if (ticking) return;
+    ticking = true;
+    requestAnimationFrame(paint);
+  };
+
+  /* A resize changes the clamp on the font size, which changes the height of
+     the wordmark, which changes where the turn is supposed to finish. */
+  const remeasure = (): void => {
+    measure();
+    tick();
+  };
+
+  /* Under reduced motion the poster is static at whatever angle it is drawn
+     at, which is the stylesheet's, so the driver hands the element back rather
+     than freezing it at the angle the reader happened to be at. Live, because
+     the preference can be turned on with the page already open and the page
+     should stop moving when it is. */
+  const listen = (on: boolean): void => {
+    if (on) {
+      window.addEventListener('scroll', tick, { passive: true });
+      window.addEventListener('resize', remeasure, { passive: true });
+    } else {
+      window.removeEventListener('scroll', tick);
+      window.removeEventListener('resize', remeasure);
+    }
+  };
+
+  const setup = (): void => {
+    if (reduced.matches) {
+      listen(false);
+      for (const turn of turns) turn.el.style.removeProperty('transform');
+      return;
+    }
+    listen(true);
+    remeasure();
+  };
+
+  reduced.addEventListener('change', setup);
+  setup();
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -785,11 +785,23 @@ summary,
 
    The origin is the left edge because everything else on the page starts there:
    the brand, the meta dot, the paragraph, the button. Spun about its centre the
-   wordmark lands ninety pixels in from all of them. */
+   wordmark lands ninety pixels in from all of them.
+
+   The axis and the two angles are custom properties because the scroll driver
+   in `wordmark.ts` reads them back rather than keeping a second copy: `--far`
+   is where the turn arrives once the wordmark has scrolled out of the frame,
+   and the value written here is the only place either number lives. Nothing
+   but this stylesheet decides how the wordmark is turned, at rest or moving.
+   With the script absent, disabled, or refused by reduced motion, `--tilt` is
+   what stands, which is the poster exactly as it shipped. */
 .hero h1 {
+  --axis: 4, -10, -0.9;
+  --tilt: 34deg;
+  --far: 47deg;
+
   font-size: clamp(4rem, 13.3vw, 12.5rem);
   color: var(--on-ink);
-  transform: rotate3d(4, -10, -0.9, 34deg);
+  transform: rotate3d(var(--axis), var(--tilt));
   transform-origin: 0% 50%;
 }
 
@@ -800,12 +812,19 @@ summary,
 /* The second line is drawn rather than filled. It is the one moment of pure
    swagger on the page, and it costs nothing but a stroke. It also carries its
    own turn on top of the line's, so the two lines fall away at different rates
-   and the pair reads as depth rather than as one sheared block. */
+   and the pair reads as depth rather than as one sheared block.
+
+   It travels the same thirteen degrees as the line above it. Giving it more
+   would close the gap between the two turns as the page scrolls, and the gap
+   is the whole reason there are two of them. */
 .hero h1 .out {
+  --tilt: 18deg;
+  --far: 31deg;
+
   margin-left: clamp(0rem, 13vw, 11.5rem);
   color: transparent;
   -webkit-text-stroke: clamp(1.4px, 0.15vw, 2.4px) var(--on-ink);
-  transform: rotate3d(4, -10, -0.9, 18deg);
+  transform: rotate3d(var(--axis), var(--tilt));
   transform-origin: 0% 50%;
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -5246,9 +5246,20 @@ span.buoy__p {
     order: 1;
   }
 
+  /* Label above value, not beside it. A label column is a bargain that only
+     pays while the value column is wide enough to be a column: at 390 a 5.6rem
+     label leaves 217px, and a value like "Live, sail together, one world
+     staying consistent" spends three lines in it against two at full width. So
+     the label column costs height rather than saving it, and it is the reason
+     these read as cramped. Stacked they cost nothing - every one of these dt
+     is already uppercase mono micro-type, which is a label whether or not it
+     has a column to sit in. */
   .specs > div,
-  .fs__read > div {
-    grid-template-columns: 5.6rem minmax(0, 1fr);
+  .fs__read > div,
+  .wt__read > div,
+  .skim > div {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.1rem;
   }
 
   .role {
@@ -5388,20 +5399,6 @@ span.buoy__p {
 
   .card[data-fold] .deep__go {
     display: inline-flex;
-  }
-}
-
-/* Phones only, and one rule. Everywhere wider, the skim's label column leaves
-   the sentence beside it four hundred pixels or more and the alignment down
-   the column is worth having. On a 390 handset it leaves two hundred and
-   forty, which is four words a line, so the label steps above the sentence
-   and both take the full width - the same shape the about-page facts use for
-   the same reason. Costs about 130px of page and buys back a readable
-   measure, which on the one device that is all measure is the better trade. */
-@media (max-width: 470px) {
-  .skim > div {
-    grid-template-columns: 1fr;
-    gap: 0.1rem;
   }
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4963,6 +4963,39 @@ span.buoy__p {
   }
 }
 
+/* Nothing sits a rail beside its content under 700. The phone band already
+   collapsed at 620, and 620 was enough right up until a viewport landed
+   between the two - a tablet in split view, a foldable half open - and got a
+   140px rail against a 454px column with no breakpoint to catch it. The rail
+   is a desktop affordance; the moment the content column is the narrower half
+   of a small screen it should be a header instead. Cheaper to move the
+   boundary than to keep guessing which devices live under it. */
+@media (max-width: 700px) {
+  .head,
+  .about,
+  .card__hero,
+  .card__cols,
+  .card--full .card__cols,
+  .role,
+  .skg {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  /* The rail was carrying the gap between the two columns; stacked, that same
+     gap is dead space between a label and the thing it labels. */
+  .head {
+    gap: 0.8rem;
+  }
+
+  .skg {
+    gap: 0.5rem;
+  }
+
+  .role {
+    gap: 0.4rem;
+  }
+}
+
 @media (max-width: 620px) {
   :root {
     --pad: 1rem;


### PR DESCRIPTION
## Summary

The live site was broken on real iPhones. The captain reviewed it at ~430 CSS px and found the desktop two-column grid still rendering, label/value pairs printing on top of each other, headlines breaking mid-word, and a horizontal scroll. Batch 9 measured 390 in Chromium and saw none of it.

One cause explains all six symptoms. Every phone breakpoint in the stylesheet used Media Queries Level 4 range syntax (`@media (width <= 620px)`). A browser that cannot parse that syntax drops the whole block, so iOS Safari under 16.4 was served the desktop layout with no mobile rules at all. That fix went out on its own as #28 and is already on master (`84a9449`). This branch is rebased on top of it, so what is left here is everything that came after.

On top of it: the phone band gets real coverage at 390, 430 and 620 rather than 390 alone, the hero wordmark keeps turning as it scrolls out of frame, the skills index takes the captain's chip list with corrected evidence links, and there is a second egg.

Two things to look at rather than skim, both called out below: the saltline and Ember Wilds cards each gained a technical note, and the wordmark now has a scroll listener on it.

## Changes

**Phone band** (`62efca0`, `9761ae0`, `a06f27f`) - the rail+content section grid collapses below 700px rather than 620px, which is what left 390-440 on the desktop grid. Every label/value `dl` stacks label above value on phones, which is what fixed the overlapping text in the technical notes and the education degrees. `verify.mjs` gained a phone-band block asserting single column, no intersecting text nodes, and `scrollWidth <= viewport` at all three widths.

**The wordmark turns as you scroll** (`88e27bc`) - `src/scripts/wordmark.ts` drives the hero h1's `rotate3d` off scroll position, deepening 34 to 47 degrees over the wordmark's own exit distance. The two angles and the axis live in `global.css` as custom properties and the driver reads them back, so the stylesheet is still the only place the tilt is defined and the static poster stands wherever the script does not run. Deeper rather than flatter is forced, not taste: the rotation is mostly about Y, so flattening un-foreshortens the block and grows "UPPAL" 150px wider at 1440, which is the sideways scroll this branch exists to remove. rAF rather than `animation-timeline: scroll()`, because that wants Safari 26 and the phone that opened this batch cannot parse a media query range.

**Skills** (`7338eff`, `d26329c`) - the captain's list: Redux, Microservices and Linux out, babylon.js, colyseus.js and Helm in. Then his fact-check against both project repos: saltline is Babylon plus Colyseus, Ember Wilds is three.js plus Colyseus. So three.js drops saltline and picks up Ember Wilds, colyseus.js claims both room servers, and 28 of 32 chips point at on-page evidence.

> Worth stopping on: to make those references land, the saltline card gained a `Transport` note and the Ember Wilds card gained `Transport` and `Renderer`. The section's own rule is that a reference has to arrive somewhere the reader can see the thing, and neither card named either technology. If you would rather the cards stayed as they were, the three rows come out and the two chips go back to the resume-only treatment.

**Sonia** (`a38218d`) - typing `sonia` swaps the wordmark to Sonia Uppal and points the hero's one action at her LinkedIn. Typing it again puts the page back, and so does a reload; nothing is stored and nothing is sent. It shares the Konami listener's sequence matching, modifier and text-field guards, and warm import, so both payloads still load lazily and neither ships to a page that is only read.

## Output

Verify, against a lab build:

```
PASS - no failures
206 checks, 0 failures
```

Page height, this run:

```
1440   12654   budget 13000
 390   12492   budget 13200
 430   12309
 620   11712
```

The mobile collapse work was proved zero-diff on desktop before the two commits that change desktop on purpose: computed style and border box compared element by element across all 1760 elements at 1440, no differences. A pixel diff is useless here because the hero canvas is nondeterministic. The wordmark and skills commits do change 1440 - the first only once the reader scrolls, the second in the two project cards and the chip list.

The wordmark, at 4x CPU throttling, A/B against the same build with the driver unwired:

```
430    26.11ms per frame   vs 25.83 baseline   (+0.28)
1440   83.61ms per frame   vs 83.56 baseline   (+0.05)
```

The 84ms frame at 1440 is the pre-existing hero canvas, not this. Hero contrast is unaffected: 6.66 to 6.59 at 390, 6.68 to 6.55 at 430, and 5.41 to 5.98 at 1440, against a 3:1 bar. Under `prefers-reduced-motion` the driver writes no angle at all and hands the element back to the stylesheet, live - three scroll positions, one transform, empty inline style.

The name swap, asserted at each width:

```
390    ink reaches 260 of 390    turn and line box identical    restores exactly
430    ink reaches 286 of 430    turn and line box identical    restores exactly
1440   ink reaches 767 of 1440   turn and line box identical    restores exactly
```

Known and untouched: 768 is the tallest viewport on the page at 15417px. It sits above the 765 breakpoint, so it gets neither the folds nor the swipe rows. That predates this branch and is not something I fixed here.
