### PR TITLE
[site] Konami physics egg: the floor gives way

### DIFF
--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -122,41 +122,43 @@ const ratioOf = (a, b) => {
 const SWEEP = [0.12, 0.4, 0.65, 0.9].flatMap((fx) => [0.18, 0.45, 0.8].map((fy) => [fx, fy]));
 
 async function heroContrast(page, width, height, spots = SWEEP) {
-  const hero = await page.evaluate(() => {
+  /* The hero frame and the type inside it in one read. Taken as two, an
+     earlier check that left the focus deep in the page can have the browser
+     scroll it back down in between, and every box then measures below the
+     clip the screenshot is cut to - nothing lands in it and there is no worst
+     case to report. */
+  const { hero, all } = await page.evaluate((sels) => {
     window.scrollTo({ top: 0, behavior: 'instant' });
-    const r = document.querySelector('.hero').getBoundingClientRect();
-    return { y: r.y, w: r.width, h: r.height };
-  });
-  const boxes = (
-    await page.evaluate(
-      (sels) =>
-        sels.map((s) => {
-          const el = document.querySelector(s);
-          if (!el) return null;
-          const r = el.getBoundingClientRect();
-          const cs = getComputedStyle(el);
-          // Same rule as the CSS walk: an unfilled glyph is drawn by its stroke.
-          const col = (cs.color.match(/[\d.]+/g) ?? []).map(Number);
-          const stroked =
-            col.length === 4 && col[3] === 0 && parseFloat(cs.webkitTextStrokeWidth) > 0;
-          return {
-            s,
-            x: r.x,
-            y: r.y,
-            w: r.width,
-            h: r.height,
-            col: (stroked ? cs.webkitTextStrokeColor : cs.color)
-              .match(/[\d.]+/g)
-              .slice(0, 3)
-              .map(Number),
-            own: cs.backgroundColor,
-            px: parseFloat(cs.fontSize),
-            wt: parseInt(cs.fontWeight, 10),
-          };
-        }),
-      HERO_TEXT,
-    )
-  ).filter((b) => b && b.w >= 1);
+    const f = document.querySelector('.hero').getBoundingClientRect();
+    return {
+      hero: { y: f.y, w: f.width, h: f.height },
+      all: sels.map((s) => {
+        const el = document.querySelector(s);
+        if (!el) return null;
+        const r = el.getBoundingClientRect();
+        const cs = getComputedStyle(el);
+        // Same rule as the CSS walk: an unfilled glyph is drawn by its stroke.
+        const col = (cs.color.match(/[\d.]+/g) ?? []).map(Number);
+        const stroked =
+          col.length === 4 && col[3] === 0 && parseFloat(cs.webkitTextStrokeWidth) > 0;
+        return {
+          s,
+          x: r.x,
+          y: r.y,
+          w: r.width,
+          h: r.height,
+          col: (stroked ? cs.webkitTextStrokeColor : cs.color)
+            .match(/[\d.]+/g)
+            .slice(0, 3)
+            .map(Number),
+          own: cs.backgroundColor,
+          px: parseFloat(cs.fontSize),
+          wt: parseInt(cs.fontWeight, 10),
+        };
+      }),
+    };
+  }, HERO_TEXT);
+  const boxes = all.filter((b) => b && b.w >= 1);
 
   const worst = new Map();
   for (const [fx, fy] of spots) {
@@ -216,9 +218,18 @@ async function heroContrast(page, width, height, spots = SWEEP) {
   await page.mouse.move(width / 2, hero.y + hero.h * 0.5);
 
   return boxes.map((b) => {
-    const { got, ground, at } = worst.get(b.s);
     const need = b.px >= 24 || (b.px >= 18.66 && b.wt >= 700) ? 3 : 4.5;
-    return { sel: b.s, need, got: Math.round(got * 100) / 100, ground: ground.join(','), at };
+    // Fails loudly rather than throwing: a box that never landed in the clip
+    // has not been checked, and unchecked is not the same as passing.
+    const w = worst.get(b.s);
+    if (!w) return { sel: b.s, need, got: 0, ground: 'never on the hero frame', at: '-' };
+    return {
+      sel: b.s,
+      need,
+      got: Math.round(w.got * 100) / 100,
+      ground: w.ground.join(','),
+      at: w.at,
+    };
   });
 }
 
@@ -1482,7 +1493,14 @@ await run(
             }),
           ms,
         );
-      note((await frames(700)) > 20, 'the framed game animates while it is watched');
+      /* Running against parked, not against a frame rate. The game's own loop
+         was measured between 13 and 93fps in a headless frame that was fully
+         on screen the whole time, so 20 frames in 700ms - 29fps - fails as
+         though the loop were broken. Counted over long enough that the slowest
+         of those still clears the bar by a wide margin, and the bar is set
+         where it means something: the offscreen half below allows 1. */
+      const on = await frames(2000);
+      note(on > 8, 'the framed game animates while it is watched', `${on} frames on screen`);
       await page.evaluate(() => window.scrollTo({ top: 0, behavior: 'instant' }));
       await page.waitForTimeout(1000);
       const off = await frames(900);

--- a/src/scripts/gravity.ts
+++ b/src/scripts/gravity.ts
@@ -626,12 +626,21 @@ export function drop(): void {
       if (el.getAttribute('style') === '') el.removeAttribute('style');
     }
     window.scrollTo({ top: sy, left: sx, behavior: 'instant' });
-    /* The nav bar and the reveal observer both watch scrolling, and the events
-       for the jump home arrive after this returns. The flag stays up one more
-       frame so neither of them reads the snap back as the reader moving. */
-    requestAnimationFrame(() => {
-      if (!live) document.documentElement.removeAttribute('data-fell');
-    });
+    /* The nav bar watches scrolling, and the events for the jump home arrive
+       after this returns - as can a second one, because a click that cancels
+       the egg also does whatever a click does, and focusing something scrolls
+       it into view. So the flag comes down on the page going quiet rather than
+       on the next frame, and none of it reads as the reader moving. */
+    let quiet = 0;
+    const rest = (): void => {
+      clearTimeout(quiet);
+      quiet = window.setTimeout(() => {
+        window.removeEventListener('scroll', rest, true);
+        if (!live) document.documentElement.removeAttribute('data-fell');
+      }, 160);
+    };
+    window.addEventListener('scroll', rest, { capture: true, passive: true });
+    rest();
     for (const type of ENDS) window.removeEventListener(type, undo, true);
   };
 

--- a/src/scripts/gravity.ts
+++ b/src/scripts/gravity.ts
@@ -44,6 +44,24 @@ const CAP = 240;
    as the letters would. */
 const LETTERS_ABOVE = 26;
 
+/* px/s². Nothing here is metric - the unit is the page, and this is the
+   number that takes a letter the length of the document in about three
+   seconds: long enough to be a fall and short enough to sit through. */
+const G = 2800;
+
+/* Every letter leaves slightly differently, or two hundred of them move like
+   one sheet. Sideways in px/s, spin in rad/s, and a few frames of stagger so
+   the release is a ripple rather than a switch. */
+const DRIFT = 46;
+const SPIN = 2.6;
+const HOLD = 150;
+
+/* A page has a bottom, and the ink stops just short of it rather than
+   straddling it. */
+const FLOOR_GAP = 8;
+
+const rand = (lo: number, hi: number): number => lo + Math.random() * (hi - lo);
+
 /* A letter never drawn is a bitmap never made, so the raster happens the first
    frame a letter is on screen rather than all at once behind the keystroke. */
 interface Sprite {
@@ -79,6 +97,11 @@ interface Particle {
   vy: number;
   rot: number;
   vr: number;
+  /* ms after the trigger before this one lets go. */
+  hold: number;
+  /* Down and done. A resting letter is skipped by the loop, and the loop ends
+     when there is nothing left that is not resting. */
+  rest: boolean;
   sp: Sprite | null;
 }
 
@@ -239,10 +262,12 @@ export function drop(): void {
         y: r.top + sy + r.height / 2,
         rw: r.width,
         rh: r.height,
-        vx: 0,
-        vy: 0,
+        vx: rand(-DRIFT, DRIFT),
+        vy: rand(-40, 40),
         rot: lean,
-        vr: 0,
+        vr: rand(-SPIN, SPIN),
+        hold: rand(0, HOLD),
+        rest: false,
         sp: null,
       });
     }
@@ -266,11 +291,24 @@ export function drop(): void {
   canvas.height = Math.ceil(window.innerHeight * dpr);
   document.body.appendChild(canvas);
 
+  /* Nothing counts as scrolled into view while this runs, or the fall marks
+     half the page as already seen and the reader never gets its first look. */
+  document.documentElement.setAttribute('data-fell', '');
+
   for (const el of hidden) el.style.visibility = 'hidden';
   for (const el of faded) {
+    /* Typing the code scrolls the page, so some of these are still mid-reveal,
+       and a running animation outranks an inline declaration. Whatever they
+       were in the middle of arriving from, they have arrived. */
+    for (const a of el.getAnimations()) a.cancel();
     el.style.transition = 'opacity 260ms linear';
     el.style.opacity = '0';
   }
+  /* Once faded, gone for good: opacity is a property animations can win back
+     and visibility, here, is not. */
+  const seal = setTimeout(() => {
+    for (const el of faded) el.style.visibility = 'hidden';
+  }, 300);
 
   const paint = (): void => {
     const vw = window.innerWidth;
@@ -306,17 +344,56 @@ export function drop(): void {
     }
   };
 
+  /* The bottom of the document, which is where the fall ends. The page has
+     not moved and is not going to - every block that left is still holding
+     its own box - so this is measured once and stays true. */
+  const floor = document.documentElement.scrollHeight - FLOOR_GAP;
+
+  let raf = 0;
+  let last = 0;
+  let clock = 0;
+
+  const step = (now: number): void => {
+    if (!live) return;
+    /* Clamped, because a tab that was in the background hands back a delta of
+       several seconds and every letter would arrive already buried. */
+    const dt = last ? Math.min(1 / 30, (now - last) / 1000) : 1 / 60;
+    last = now;
+    clock += dt * 1000;
+
+    let awake = 0;
+    for (const q of parts) {
+      if (q.rest) continue;
+      awake++;
+      if (clock < q.hold) continue;
+      q.vy += G * dt;
+      q.x += q.vx * dt;
+      q.y += q.vy * dt;
+      q.rot += q.vr * dt;
+      const low = floor - q.rh / 2;
+      if (q.y >= low) {
+        q.y = low;
+        q.rest = true;
+        awake--;
+      }
+    }
+
+    paint();
+    raf = awake ? requestAnimationFrame(step) : 0;
+  };
+
   paint();
+  raf = requestAnimationFrame(step);
 
   const undo = (): void => {
     if (!live) return;
     live = false;
+    if (raf) cancelAnimationFrame(raf);
+    clearTimeout(seal);
     canvas.remove();
-    for (const el of hidden) {
+    document.documentElement.removeAttribute('data-fell');
+    for (const el of [...hidden, ...faded]) {
       el.style.removeProperty('visibility');
-      if (el.getAttribute('style') === '') el.removeAttribute('style');
-    }
-    for (const el of faded) {
       el.style.removeProperty('transition');
       el.style.removeProperty('opacity');
       if (el.getAttribute('style') === '') el.removeAttribute('style');

--- a/src/scripts/gravity.ts
+++ b/src/scripts/gravity.ts
@@ -33,12 +33,22 @@ const TYPE =
    design lab is not part of the page and the skip link is not on it yet. */
 const NOT = '[data-lab], .inspect-bar, .sr, .skip, [hidden]';
 
-/* The whole document's type is far more than this. What the cap buys is a
-   per-frame draw count that a 4x-throttled phone can hold at 60, so the type
-   that does not fit the budget leaves by fading rather than by janking. The
-   sort below spends the budget on the biggest type on the page, which is the
-   type worth watching fall. */
+/* The whole document's type is far more than this. The cap bounds the one-off
+   work behind the keystroke - cutting the page up and rastering it - and the
+   memory the sprites take; the type it does not reach leaves by fading rather
+   than by janking. The sort below spends it on the biggest type on the page,
+   which is the type worth watching fall. */
 const CAP = 240;
+
+/* Pixels the overlay is allowed to be. This, not the letter count, is what a
+   phone pays for a canvas it redraws every frame: at 430 on a 4x-throttled
+   phone the same fall runs 43fps at device resolution and 86fps at half of it,
+   while going from 240 letters to 120 bought two frames a second and landing
+   them sooner bought four. So the canvas takes a pixel budget rather than the
+   device ratio. It costs nothing below a 2x screen and buys phones the frame
+   rate; tumbling type does not need the sharpness, the page underneath keeps
+   its own, and the moment the heap sleeps this is gone. */
+const FILL = 700_000;
 
 /* Above this, a block comes apart into letters; below it, into words. Word
    pieces of body copy read as debris at a distance and cost a fifth as much
@@ -257,7 +267,14 @@ function pieces(el: HTMLElement, byLetter: boolean): Array<{ t: string; r: DOMRe
 export function drop(): void {
   if (live) return;
 
-  const dpr = Math.min(2, window.devicePixelRatio || 1);
+  const dpr = Math.max(
+    1,
+    Math.min(
+      2,
+      window.devicePixelRatio || 1,
+      Math.sqrt(FILL / (window.innerWidth * window.innerHeight)),
+    ),
+  );
   const sx = window.scrollX;
   const sy = window.scrollY;
 
@@ -365,38 +382,127 @@ export function drop(): void {
     for (const el of faded) el.style.visibility = 'hidden';
   }, 300);
 
+  /* A letter that has stopped never moves again, so it is stamped once into a
+     layer of its own and every later frame blits that. Without it the whole
+     heap is redrawn per frame from the moment it lands, which is where a slow
+     phone gives out: 240 turned sprites, all on screen at once, forever. */
+  const heap = document.createElement('canvas');
+  heap.width = canvas.width;
+  heap.height = canvas.height;
+  const hctx = heap.getContext('2d');
+  const still: Particle[] = [];
+  let baked = 0;
+  let heapX = NaN;
+  let heapY = NaN;
+  /* Screen box the moving letters filled last frame: the ink this frame has to
+     clean up after. Empty until something is in it. */
+  let wasX0 = Infinity;
+  let wasY0 = Infinity;
+  let wasX1 = -Infinity;
+  let wasY1 = -Infinity;
+
+  const stamp = (g: CanvasRenderingContext2D, q: Particle, px: number, py: number): void => {
+    if (!q.sp) {
+      const key = `${q.s}:${q.t}`;
+      let sp = sprites.get(key);
+      if (sp === undefined) {
+        const st = styles[q.s];
+        sp = st ? raster(q.t, st, q.rw, q.rh, dpr) : null;
+        sprites.set(key, sp);
+      }
+      if (!sp) return;
+      q.sp = sp;
+    }
+    const { c, w, h } = q.sp;
+    const cos = Math.cos(q.rot);
+    const sin = Math.sin(q.rot);
+    g.setTransform(cos * dpr, sin * dpr, -sin * dpr, cos * dpr, px * dpr, py * dpr);
+    g.drawImage(c, -w / 2, -h / 2, w, h);
+  };
+
   const paint = (): void => {
     const vw = window.innerWidth;
     const vh = window.innerHeight;
     const ox = window.scrollX;
     const oy = window.scrollY;
-    ctx.setTransform(1, 0, 0, 1, 0, 0);
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    /* Culled against the screen rather than against its own box, which is not
+       known until the bitmap exists. The margin is generous enough to cover
+       the biggest letter on the page turned on its corner. */
+    const off = (px: number, py: number): boolean =>
+      px < -400 || px > vw + 400 || py < -400 || py > vh + 400;
 
+    /* Where the letters that are still moving are, this frame. */
+    let x0 = Infinity;
+    let y0 = Infinity;
+    let x1 = -Infinity;
+    let y1 = -Infinity;
     for (const q of parts) {
+      if (q.rest) continue;
       const px = q.x - ox;
       const py = q.y - oy;
-      /* Culled against the screen rather than against its own box, which is
-         not known until the bitmap exists. The margin is generous enough to
-         cover the biggest letter on the page turned on its corner. */
-      if (px < -400 || px > vw + 400 || py < -400 || py > vh + 400) continue;
-      if (!q.sp) {
-        const key = `${q.s}:${q.t}`;
-        let sp = sprites.get(key);
-        if (sp === undefined) {
-          const st = styles[q.s];
-          sp = st ? raster(q.t, st, q.rw, q.rh, dpr) : null;
-          sprites.set(key, sp);
-        }
-        if (!sp) continue;
-        q.sp = sp;
-      }
-      const { c, w, h } = q.sp;
-      const cos = Math.cos(q.rot);
-      const sin = Math.sin(q.rot);
-      ctx.setTransform(cos * dpr, sin * dpr, -sin * dpr, cos * dpr, px * dpr, py * dpr);
-      ctx.drawImage(c, -w / 2, -h / 2, w, h);
+      if (off(px, py)) continue;
+      const r = (q.rw + q.rh) / 2 + 4;
+      if (px - r < x0) x0 = px - r;
+      if (py - r < y0) y0 = py - r;
+      if (px + r > x1) x1 = px + r;
+      if (py + r > y1) y1 = py + r;
     }
+
+    // The layer holds screen positions, so a scroll invalidates all of it.
+    const rode = ox !== heapX || oy !== heapY;
+    if (rode && hctx) {
+      hctx.setTransform(1, 0, 0, 1, 0, 0);
+      hctx.clearRect(0, 0, heap.width, heap.height);
+      baked = 0;
+      heapX = ox;
+      heapY = oy;
+    }
+
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    if (rode || !hctx) {
+      /* The page is moving under the letters, so every pixel is wrong anyway
+         and a settled layer would be rebuilt from nothing for one frame's use.
+         Straight draw. Little has landed this early to make it worth more. */
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      for (const q of parts) {
+        const px = q.x - ox;
+        const py = q.y - oy;
+        if (off(px, py)) continue;
+        stamp(ctx, q, px, py);
+      }
+    } else {
+      for (; baked < still.length; baked++) {
+        const q = still[baked];
+        if (!q || off(q.x - ox, q.y - oy)) continue;
+        stamp(hctx, q, q.x - ox, q.y - oy);
+      }
+      /* Everything outside this box is heap that has not changed since it was
+         drawn, so the frame only repairs where the bouncing is: clearing and
+         re-blitting the whole screen every frame costs three megapixels of fill
+         on a phone, and that alone was holding the settle to thirty. */
+      const bx0 = Math.max(0, Math.floor(Math.min(x0, wasX0)));
+      const by0 = Math.max(0, Math.floor(Math.min(y0, wasY0)));
+      const bx1 = Math.min(vw, Math.ceil(Math.max(x1, wasX1)));
+      const by1 = Math.min(vh, Math.ceil(Math.max(y1, wasY1)));
+      if (bx1 > bx0 && by1 > by0) {
+        const w = (bx1 - bx0) * dpr;
+        const h = (by1 - by0) * dpr;
+        ctx.clearRect(bx0 * dpr, by0 * dpr, w, h);
+        ctx.drawImage(heap, bx0 * dpr, by0 * dpr, w, h, bx0 * dpr, by0 * dpr, w, h);
+      }
+      for (const q of parts) {
+        if (q.rest) continue;
+        const px = q.x - ox;
+        const py = q.y - oy;
+        if (off(px, py)) continue;
+        stamp(ctx, q, px, py);
+      }
+    }
+
+    wasX0 = x0;
+    wasY0 = y0;
+    wasX1 = x1;
+    wasY1 = y1;
   };
 
   /* The bottom of the document, which is where the fall ends. The page has
@@ -469,6 +575,7 @@ export function drop(): void {
         q.rest = true;
         q.vr = 0;
         awake--;
+        still.push(q);
         /* What this letter adds to the columns beneath it: its ink spread over
            the width it actually covers, so a word lying flat raises a wide
            strip by a little and the same word on its end raises a narrow one

--- a/src/scripts/gravity.ts
+++ b/src/scripts/gravity.ts
@@ -33,39 +33,29 @@ const TYPE =
    design lab is not part of the page and the skip link is not on it yet. */
 const NOT = '[data-lab], .inspect-bar, .sr, .skip, [hidden]';
 
-/* The whole document's type is far more than this. The cap bounds the one-off
-   work behind the keystroke - cutting the page up and rastering it - and the
-   memory the sprites take; the type it does not reach leaves by fading rather
-   than by janking. The sort below spends it on the biggest type on the page,
-   which is the type worth watching fall. */
-const CAP = 240;
-
-/* Pixels the overlay is allowed to be. This, not the letter count, is what a
-   phone pays for a canvas it redraws every frame: at 430 on a 4x-throttled
-   phone the same fall runs 43fps at device resolution and 86fps at half of it,
-   while going from 240 letters to 120 bought two frames a second and landing
-   them sooner bought four. So the canvas takes a pixel budget rather than the
-   device ratio. It costs nothing below a 2x screen and buys phones the frame
-   rate; tumbling type does not need the sharpness, the page underneath keeps
-   its own, and the moment the heap sleeps this is gone. */
+/* Pixels the overlay is allowed to be, rather than whatever the screen claims.
+   A letter on screen costs about 21us of a 4x-throttled phone's frame, and it
+   splits into 12us of issuing the draw at all and the rest of it per pixel of
+   sprite - so at a 3x device ratio the same letter is half as expensive again
+   as it is at 1.3x. Tumbling type does not need the sharpness, the page
+   underneath keeps its own, and the moment the heap sleeps this is gone. */
 const FILL = 700_000;
-
-/* Above this, a block comes apart into letters; below it, into words. Word
-   pieces of body copy read as debris at a distance and cost a fifth as much
-   as the letters would. */
-const LETTERS_ABOVE = 26;
 
 /* px/s². Nothing here is metric - the unit is the page, and this is the
    number that takes a letter the length of the document in about three
    seconds: long enough to be a fall and short enough to sit through. */
 const G = 2800;
 
-/* Every letter leaves slightly differently, or two hundred of them move like
-   one sheet. Sideways in px/s, spin in rad/s, and a few frames of stagger so
-   the release is a ripple rather than a switch. */
+/* Every letter leaves slightly differently, or thousands of them move like one
+   sheet. Sideways in px/s, spin in rad/s, and a few frames of stagger so the
+   release is a ripple rather than a switch. */
 const DRIFT = 46;
 const SPIN = 2.6;
 const HOLD = 150;
+
+/* ms of extra stagger per px down a block, so a tall paragraph comes apart
+   from its own top line rather than all at once. */
+const LINE_LAG = 0.5;
 
 /* A page has a bottom, and the ink stops short of it rather than straddling
    it. Wide enough to cover the padding a sprite carries for its stroke and
@@ -93,10 +83,20 @@ const CAM_BRAKE = 2.2;
    down the document as fast as they do. */
 const WAKE = 0.66;
 
-/* How much of the impact speed a letter keeps. A third gets three bounces out
-   of a fall the length of the page and none out of a letter that started near
-   the bottom, which is the right answer to both. */
-const REST = 0.3;
+/* How much of the impact speed a letter keeps, and the speed below which the
+   next bounce would not clear its own height, so it has landed rather than
+   bounced.
+ *
+ * These are the frame rate, not the feel. A letter costs nothing on the page
+ * and costs a draw every frame from the moment it lets go until the moment it
+ * stops, and eight thousand letters all arrive at the floor inside the same
+ * two seconds. A third of the impact speed kept is three bounces and about a
+ * second and a half of them, which put seven thousand letters on the screen at
+ * once and the fall at 19.8fps on a 4x-throttled phone. A sixth is one clear
+ * bounce and a settle, which is what a letter of ink landing in a heap of
+ * other letters looks like anyway, and it is 30.6fps. */
+const REST = 0.16;
+const LAND_V = 300;
 
 /* Sideways speed kept through an impact, and the share of the landing speed
    thrown sideways by it. A hard landing scattering outward is most of what a
@@ -108,28 +108,45 @@ const SPLASH = 0.18;
    paid for and did not get to watch land. */
 const WALL = 0.5;
 
-/* Below this, the next bounce would not clear the letter's own height, so it
-   has not bounced - it has landed. */
-const LAND_V = 200;
-
 /* The heap is a height per column of the page rather than letter against
    letter: two hundred bodies is twenty thousand pairs and this is a hundred
    and twenty numbers. A letter lands on what the columns it covers are
    standing at, then raises them by rather less than its own height, because
    type in a pile interlocks instead of stacking.
  *
- * Landing on the highest of those columns is the obvious rule and the wrong
- * one. It ratchets: one tall column drags every neighbour it touches up with
- * it, wide pieces couple columns that are nowhere near each other, and two
- * hundred letters build a tower several screens tall - measured at 3858px on
- * a 430 phone, where a heap has no business being deeper than a screen. So
- * the surface is halfway between the highest column and their average, which
- * lets a letter sink into the dip beside a tall one, and the whole heap is
- * capped at rather less than a screen. Past the cap the letters pack in
- * rather than stack up, which is what a heap of paper does anyway. */
+ * It rests on halfway between the highest column it covers and their average,
+ * rather than on the highest, so a letter can sink into the dip beside a tall
+ * one instead of bridging every gap it meets.
+ *
+ * What it raises them by is its own ink divided across them. Raising them all
+ * to the height of the tallest instead - which is the obvious way to write it
+ * - is not a deposit but a ratchet: a wide piece lifts a whole span to its own
+ * peak, the next piece lifts it again from there, and eight thousand letters
+ * put every column through the cap inside the first second. Everything landing
+ * after that sits on a flat lid at the same height - a shelf of type with the
+ * real heap thinning away underneath it, and a hard horizontal line ruled
+ * across the page.
+ *
+ * Dividing across the columns makes the finished depth a quantity that can be
+ * solved for rather than tuned: it is the ink collected over the width it has
+ * to lie in. So the depth is asked for directly, as a share of the screen, and
+ * what each letter counts for falls out of it - which is what lets the same
+ * numbers hold for a phone with eight thousand letters and a desktop with
+ * thirteen thousand. The cap is then a backstop and not a shape; a page would
+ * have to be about twice as dense as this one before it touched anything.
+ *
+ * Columns that can only grow upwards grow into a picket fence - on a desktop,
+ * where the text sits in a narrow measure and the columns are many, the heap
+ * came out as a row of separate towers with bare floor between them. Type does
+ * not stand like that, so the heap sheds sideways: any column overhanging its
+ * neighbour by more than the angle of repose hands half the excess over, twice
+ * a frame while things are still landing. Volume is unchanged; the towers
+ * become dunes. */
 const COL = 12;
-const INK = 0.3;
-const PILE_MAX = 0.3;
+const INK_MAX = 0.3;
+const PILE_AVG = 0.22;
+const PILE_MAX = 0.45;
+const REPOSE = 9;
 
 /* A backstop, not a design. Nothing should still be moving by here; if
    something is, it stops being interesting long before it stops moving. */
@@ -143,6 +160,10 @@ interface Sprite {
   c: HTMLCanvasElement;
   w: number;
   h: number;
+  /* Where the middle of the bitmap sits relative to the middle of the box the
+     browser laid the letter out in, which is the point it turns about. */
+  dx: number;
+  dy: number;
 }
 
 interface Style {
@@ -172,14 +193,23 @@ interface Particle {
   vy: number;
   rot: number;
   vr: number;
-  /* The document y this one waits for the reader to reach, then a few ms of
-     scatter on top so a line does not let go as one bar. -1 once it is off. */
-  wake: number;
   hold: number;
-  /* Down and done. A resting letter is skipped by the loop, and the loop ends
-     when there is nothing left that is not resting. */
-  rest: boolean;
+  /* Half the reach of this letter at any angle, which is what it is culled on.
+     A blanket margin has to assume the wordmark, and assuming the wordmark for
+     a 9px letter draws a band of type twice the height of the screen that
+     nobody can see - measured as most of the draw calls in the fall. */
+  r: number;
   sp: Sprite | null;
+}
+
+/* One block of type: the letters it came apart into, and where it sits. The
+   wave works on these rather than on letters, because a block that has let go
+   is hidden in the document and a block that has not is still being drawn by
+   the browser, in real text, for free. */
+interface Block {
+  el: HTMLElement;
+  y: number;
+  parts: Particle[];
 }
 
 let live = false;
@@ -206,12 +236,16 @@ function readStyle(el: Element): Style {
 /**
  * The bitmap for one piece of text in one style, made once and kept.
  *
- * It is cut to the box the browser gave that text - the advance width and the
- * line box, not the ink - and the glyph is drawn inside it on the baseline the
- * browser would have used. That is what makes frame zero of the fall identical
- * to the page: a sprite centred on its own ink instead would shift every
- * letter by its side bearing, which is invisible on one letter and reads as
- * loose, drunk spacing across a headline.
+ * It is cut to the letter's ink and carries the offset from the middle of the
+ * box the browser laid that letter out in to the middle of the bitmap. Both
+ * halves matter. A sprite centred on its own ink and drawn at the box's centre
+ * shifts every letter by its side bearing, which is invisible on one letter
+ * and reads as loose, drunk spacing across a headline - so the offset puts it
+ * back, and frame zero of the fall is the page. And a sprite cut to the line
+ * box instead is mostly nothing: a 15px letter in a line of 1.6 leading is a
+ * quarter ink and three quarters air, and the air is resampled through the
+ * rotation on every frame like anything else. Cutting it out took the fall on
+ * a phone at 4x throttle from 15.8fps to 19.8.
  */
 function raster(t: string, st: Style, rw: number, rh: number, dpr: number): Sprite | null {
   if (!gauge) return null;
@@ -219,16 +253,21 @@ function raster(t: string, st: Style, rw: number, rh: number, dpr: number): Spri
   const m = gauge.measureText(t);
   const asc = m.fontBoundingBoxAscent || m.actualBoundingBoxAscent || st.size * 0.8;
   const desc = m.fontBoundingBoxDescent || m.actualBoundingBoxDescent || st.size * 0.2;
-  /* Room for the stroke, which is drawn centred on the glyph edge and so
-     hangs half its width outside the metrics, and for ink that overshoots the
-     line box, which round letters do at every size. */
-  const pad = Math.ceil(st.sw) + 4;
-  const w = Math.ceil(rw) + pad * 2;
-  const h = Math.ceil(rh) + pad * 2;
-  if (w < 2 || h < 2 || w > 2000 || h > 2000) return null;
   /* Half-leading above, then the ascent: where the baseline sits inside a line
      box is the one thing the range rect does not tell you. */
-  const base = pad + (rh - (asc + desc)) / 2 + asc;
+  const base = (rh - (asc + desc)) / 2 + asc;
+  /* Room for the stroke, which is drawn centred on the glyph edge and so hangs
+     half its width outside the ink, and a pixel each side for the edge. */
+  const pad = Math.ceil(st.sw / 2) + 2;
+  const l = m.actualBoundingBoxLeft;
+  const right = m.actualBoundingBoxRight;
+  const up = m.actualBoundingBoxAscent;
+  const down = m.actualBoundingBoxDescent;
+  const iw = Math.ceil(l + right);
+  const ih = Math.ceil(up + down);
+  const w = iw + pad * 2;
+  const h = ih + pad * 2;
+  if (w < 2 || h < 2 || w > 2000 || h > 2000) return null;
 
   const c = document.createElement('canvas');
   c.width = Math.ceil(w * dpr);
@@ -238,24 +277,26 @@ function raster(t: string, st: Style, rw: number, rh: number, dpr: number): Spri
   ctx.scale(dpr, dpr);
   ctx.font = st.font;
   ctx.textBaseline = 'alphabetic';
+  const ox = pad + l;
+  const oy = pad + up;
   if (st.sw > 0) {
     ctx.lineWidth = st.sw;
     ctx.strokeStyle = st.stroke;
-    ctx.strokeText(t, pad, base);
+    ctx.strokeText(t, ox, oy);
   }
   ctx.fillStyle = st.fill;
-  ctx.fillText(t, pad, base);
-  return { c, w, h };
+  ctx.fillText(t, ox, oy);
+  return { c, w, h, dx: iw / 2 - l - rw / 2, dy: base - up + ih / 2 - rh / 2 };
 }
 
 /**
- * One element's type, cut into pieces with a box each.
+ * One element's type, cut into one piece per letter with a box each.
  *
  * The style is read off each text node's own parent rather than off the block,
  * because the two lines of the wordmark are one h1 and only one of them is
  * outlined.
  */
-function pieces(el: HTMLElement, byLetter: boolean): Array<{ t: string; r: DOMRect; p: Element }> {
+function pieces(el: HTMLElement): Array<{ t: string; r: DOMRect; p: Element }> {
   const out: Array<{ t: string; r: DOMRect; p: Element }> = [];
   const walk = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
   const range = document.createRange();
@@ -264,7 +305,7 @@ function pieces(el: HTMLElement, byLetter: boolean): Array<{ t: string; r: DOMRe
     if (!data.trim()) continue;
     const p = n.parentElement;
     if (!p || p.closest(NOT)) continue;
-    const re = byLetter ? /\S/g : /\S+/g;
+    const re = /\S/g;
     for (let m = re.exec(data); m; m = re.exec(data)) {
       range.setStart(n, m.index);
       range.setEnd(n, m.index + m[0].length);
@@ -293,51 +334,53 @@ export function drop(): void {
   gauge = document.createElement('canvas').getContext('2d');
   if (!gauge) return;
 
-  /* Biggest type first, so the budget is spent on the wordmark and the section
-     headings before it reaches the body copy. Everything the budget does not
-     reach is still leaving, just by fading. */
-  const blocks: Array<{ el: HTMLElement; size: number; y: number }> = [];
+  const found: HTMLElement[] = [];
   for (const el of document.querySelectorAll<HTMLElement>(TYPE)) {
     if (el.closest(NOT)) continue;
     if (!el.textContent?.trim()) continue;
-    if (blocks.some((b) => b.el.contains(el))) continue;
+    if (found.some((b) => b.contains(el))) continue;
     const box = el.getBoundingClientRect();
     if (box.width < 2 || box.height < 2) continue;
-    blocks.push({ el, size: parseFloat(getComputedStyle(el).fontSize) || 0, y: box.top + sy });
+    found.push(el);
   }
-  if (!blocks.length) return;
-  blocks.sort((a, b) => b.size - a.size);
+  if (!found.length) return;
 
   const styles: Style[] = [];
   const index = new Map<string, number>();
+  /* Every letter asks its parent what it looks like, and there are thousands
+     of letters and a few hundred parents. */
+  const byParent = new Map<Element, number>();
   const sprites = new Map<string, Sprite | null>();
-  const parts: Particle[] = [];
-  const hidden: HTMLElement[] = [];
-  const faded: Array<{ el: HTMLElement; y: number }> = [];
+  const blocks: Block[] = [];
+  let total = 0;
+  /* The furthest any one letter reaches from its own centre, which sets how
+     deep the settled layer has to be. */
+  let reach = 0;
+  /* Everything the page is about to drop, in px², which is what the heap has
+     to find room for. */
+  let area = 0;
 
-  for (const { el, size, y } of blocks) {
-    if (parts.length >= CAP) {
-      faded.push({ el, y });
-      continue;
-    }
-    const cut = pieces(el, size >= LETTERS_ABOVE);
-    if (!cut.length || parts.length + cut.length > CAP) {
-      faded.push({ el, y });
-      continue;
-    }
+  for (const el of found) {
+    const cut = pieces(el);
+    if (!cut.length) continue;
     /* The angle the block was already showing, off its own matrix. Type inside
        a turned block is drawn upright, so it is set down at that angle instead
        and the wordmark comes apart along the tilt it had rather than snapping
        level first. */
     const m = new DOMMatrixReadOnly(getComputedStyle(el).transform);
     const lean = Math.atan2(m.b, m.a);
+    const parts: Particle[] = [];
     for (const { t, r, p } of cut) {
-      const st = readStyle(p);
-      const key = styleKey(st);
-      let s = index.get(key);
+      let s = byParent.get(p);
       if (s === undefined) {
-        s = styles.push(st) - 1;
-        index.set(key, s);
+        const st = readStyle(p);
+        const key = styleKey(st);
+        s = index.get(key);
+        if (s === undefined) {
+          s = styles.push(st) - 1;
+          index.set(key, s);
+        }
+        byParent.set(p, s);
       }
       parts.push({
         t,
@@ -350,15 +393,21 @@ export function drop(): void {
         vy: rand(-40, 40),
         rot: lean,
         vr: rand(-SPIN, SPIN),
-        wake: r.top + sy,
         hold: 0,
-        rest: false,
+        r: (r.width + r.height) / 2 + 12,
         sp: null,
       });
+      area += r.width * r.height;
+      const q = parts[parts.length - 1];
+      if (q && q.r > reach) reach = q.r;
     }
-    hidden.push(el);
+    total += parts.length;
+    blocks.push({ el, y: el.getBoundingClientRect().top + sy, parts });
   }
-  if (!parts.length) return;
+  if (!total) return;
+
+  /* Release order. The wave walks this from the front and never looks back. */
+  blocks.sort((a, b) => a.y - b.y);
 
   live = true;
 
@@ -372,47 +421,100 @@ export function drop(): void {
     return;
   }
 
-  canvas.width = Math.ceil(window.innerWidth * dpr);
-  canvas.height = Math.ceil(window.innerHeight * dpr);
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+  const wall = document.documentElement.clientWidth;
+  canvas.width = Math.ceil(vw * dpr);
+  canvas.height = Math.ceil(vh * dpr);
   document.body.appendChild(canvas);
+
+  /* The bottom of the document, which is where the fall ends.
+   *
+   * Watched rather than assumed, because the page is not the constant it looks
+   * like. Hiding the type moves nothing - every block keeps its box - but the
+   * ride pulls the whole document past the viewport in four seconds, and that
+   * hydrates every `client:visible` island on the way down. One of them, the
+   * autotyper lab, renders its terminal in place of the form the server sent
+   * and takes 137px out of a 430 phone as it does. A floor measured once at
+   * the keystroke then sits below the bottom the reader can actually reach,
+   * and the heap standing on it is built partly out of view: measured 138px of
+   * it unreachable at 430 and 390, and none at 1440, which is the width where
+   * that island is already hydrated before the egg is armed.
+   *
+   * An observer rather than a read per frame: asking the document its height
+   * on a frame that has just written a style is a full layout of twelve
+   * thousand px of page, every frame, for an answer that changes twice. */
+  let docNow = document.documentElement.scrollHeight;
+  let docWas = docNow;
+  let floor = docNow - FLOOR_GAP;
+  let bottom = Math.max(0, docNow - vh);
+  const watch = new ResizeObserver(() => {
+    docNow = document.documentElement.scrollHeight;
+  });
+  watch.observe(document.body);
+
+  const cols = Math.max(1, Math.ceil(wall / COL));
+  /* Height of the heap above the floor, one entry per column. */
+  const pile = new Float32Array(cols);
+  const deepest = vh * PILE_MAX;
+  /* Solved back from the depth wanted: a letter's share of it is its own area
+     over the area of page the whole heap has to lie across. */
+  const ink = Math.min(INK_MAX, (vh * PILE_AVG * wall) / Math.max(area, 1));
+  /* Deep enough for the pile, and for the biggest letter on the page lying on
+     top of it at any angle. */
+  const bandH = Math.ceil(deepest + 2 * reach);
+
+  /* One pass each way, so the heap does not lean in the direction it is
+     walked. */
+  const slump = (): void => {
+    for (let n = 0; n < 2; n++) {
+      for (let k = 0; k < cols - 1; k++) {
+        const i = n ? cols - 2 - k : k;
+        const a = pile[i] ?? 0;
+        const b = pile[i + 1] ?? 0;
+        const over = Math.abs(a - b) - REPOSE;
+        if (over <= 0) continue;
+        const give = (a > b ? over : -over) / 2;
+        pile[i] = a - give;
+        pile[i + 1] = b + give;
+      }
+    }
+  };
 
   /* Nothing counts as scrolled into view while this runs, or the fall marks
      half the page as already seen and the reader never gets its first look. */
   document.documentElement.setAttribute('data-fell', '');
 
-  for (const el of hidden) el.style.visibility = 'hidden';
+  /* Released and still moving, compacted: a letter that lands is swapped off
+     the end of this and never costs a frame again. The alternative is a
+     `rest` test against every letter on the page, which at this count is the
+     per-frame budget spent on deciding to do nothing. */
+  const active: Particle[] = [];
+  const shown: HTMLElement[] = [];
+  let opened = 0;
 
-  /* The type the budget did not reach leaves at the same moment the letters
-     beside it do, or the page ahead of the wave has holes in it. */
-  faded.sort((a, b) => a.y - b.y);
-  const seals: number[] = [];
-  let dissolved = 0;
-  const dissolve = (el: HTMLElement): void => {
-    /* Typing the code scrolls the page, so some of these are still mid-reveal,
-       and a running animation outranks an inline declaration. Whatever they
-       were in the middle of arriving from, they have arrived. */
-    for (const a of el.getAnimations()) a.cancel();
-    el.style.transition = 'opacity 260ms linear';
-    el.style.opacity = '0';
-    /* Once faded, gone for good: opacity is a property animations can win back
-       and visibility, here, is not. */
-    seals.push(
-      window.setTimeout(() => {
-        el.style.visibility = 'hidden';
-      }, 300),
-    );
-  };
-
-  /* A letter that has stopped never moves again, so it is stamped once into a
-     layer of its own and every later frame blits that. Without it the whole
-     heap is redrawn per frame from the moment it lands, which is where a slow
-     phone gives out: 240 turned sprites, all on screen at once, forever. */
+  /* A letter that is not moving is stamped once into a layer of its own and
+     every later frame blits that. Without it the whole heap is redrawn per
+     frame from the moment it lands, and on a phone that is where the fall
+     gives out - measured at 6717 sprites in one frame on the last of the ride,
+     a 300ms frame.
+   *
+   * The layer is in document coordinates and covers only the strip of page the
+   * heap can reach, which is the pile depth plus the tallest letter on the
+   * page. An earlier version of it held a screenful of screen coordinates and
+   * so was thrown away and rebuilt on every scrolled frame, which is every
+   * frame of the ride - exactly the frames it was there to pay for. This one
+   * is a few hundred px tall, is never rebuilt, and is put on screen with a
+   * single blit at whatever offset the reader is at. */
   const heap = document.createElement('canvas');
-  heap.width = canvas.width;
-  heap.height = canvas.height;
+  heap.width = Math.ceil(wall * dpr);
+  heap.height = Math.ceil(bandH * dpr);
   const hctx = heap.getContext('2d');
   const still: Particle[] = [];
+  /* How much of `still` is already in the layer. */
   let baked = 0;
+  /* Where the top of the layer sits in the document. */
+  let bandTop = floor - deepest - reach;
   let heapX = NaN;
   let heapY = NaN;
   /* Screen box the moving letters filled last frame: the ink this frame has to
@@ -422,102 +524,121 @@ export function drop(): void {
   let wasX1 = -Infinity;
   let wasY1 = -Infinity;
 
-  const stamp = (g: CanvasRenderingContext2D, q: Particle, px: number, py: number): void => {
-    if (!q.sp) {
-      const key = `${q.s}:${q.t}`;
-      let sp = sprites.get(key);
-      if (sp === undefined) {
-        const st = styles[q.s];
-        sp = st ? raster(q.t, st, q.rw, q.rh, dpr) : null;
-        sprites.set(key, sp);
-      }
-      if (!sp) return;
-      q.sp = sp;
+  const sprite = (q: Particle): Sprite | null => {
+    if (q.sp) return q.sp;
+    const key = `${q.s}:${q.t}`;
+    let sp = sprites.get(key);
+    if (sp === undefined) {
+      const st = styles[q.s];
+      sp = st ? raster(q.t, st, q.rw, q.rh, dpr) : null;
+      sprites.set(key, sp);
     }
-    const { c, w, h } = q.sp;
+    q.sp = sp;
+    return sp;
+  };
+
+  const stamp = (g: CanvasRenderingContext2D, q: Particle, px: number, py: number): void => {
+    const sp = sprite(q);
+    if (!sp) return;
     const cos = Math.cos(q.rot);
     const sin = Math.sin(q.rot);
     g.setTransform(cos * dpr, sin * dpr, -sin * dpr, cos * dpr, px * dpr, py * dpr);
-    g.drawImage(c, -w / 2, -h / 2, w, h);
+    /* The offset is inside the transform, so the ink turns about the middle of
+       the letter's own box rather than about the middle of its ink. */
+    g.drawImage(sp.c, sp.dx - sp.w / 2, sp.dy - sp.h / 2, sp.w, sp.h);
   };
 
-  const paint = (): void => {
-    const vw = window.innerWidth;
-    const vh = window.innerHeight;
-    const ox = window.scrollX;
-    const oy = window.scrollY;
-    /* Culled against the screen rather than against its own box, which is not
-       known until the bitmap exists. The margin is generous enough to cover
-       the biggest letter on the page turned on its corner. */
-    const off = (px: number, py: number): boolean =>
-      px < -400 || px > vw + 400 || py < -400 || py > vh + 400;
-
+  /* Position is handed in rather than read. Opening a block writes a style and
+     scrolling writes a position, and reading the viewport back after either of
+     those is a forced layout of a twelve-thousand-px document every frame. The
+     loop knows where it just put the page. */
+  const paint = (ox: number, oy: number): void => {
     /* Where the letters that are still moving are, this frame. */
     let x0 = Infinity;
     let y0 = Infinity;
     let x1 = -Infinity;
     let y1 = -Infinity;
-    for (const q of parts) {
-      if (q.rest) continue;
+    for (const q of active) {
       const px = q.x - ox;
       const py = q.y - oy;
-      if (off(px, py)) continue;
-      const r = (q.rw + q.rh) / 2 + 4;
+      const r = q.r;
+      if (px < -r || px > vw + r || py < -r || py > vh + r) continue;
       if (px - r < x0) x0 = px - r;
       if (py - r < y0) y0 = py - r;
       if (px + r > x1) x1 = px + r;
       if (py + r > y1) y1 = py + r;
     }
 
-    // The layer holds screen positions, so a scroll invalidates all of it.
-    const rode = ox !== heapX || oy !== heapY;
-    if (rode && hctx) {
-      hctx.setTransform(1, 0, 0, 1, 0, 0);
-      hctx.clearRect(0, 0, heap.width, heap.height);
-      baked = 0;
-      heapX = ox;
-      heapY = oy;
-    }
-
-    ctx.setTransform(1, 0, 0, 1, 0, 0);
-    if (rode || !hctx) {
-      /* The page is moving under the letters, so every pixel is wrong anyway
-         and a settled layer would be rebuilt from nothing for one frame's use.
-         Straight draw. Little has landed this early to make it worth more. */
-      ctx.clearRect(0, 0, canvas.width, canvas.height);
-      for (const q of parts) {
-        const px = q.x - ox;
-        const py = q.y - oy;
-        if (off(px, py)) continue;
-        stamp(ctx, q, px, py);
-      }
-    } else {
+    /* Newly landed letters go into the layer, once each, forever. */
+    if (hctx) {
       for (; baked < still.length; baked++) {
         const q = still[baked];
-        if (!q || off(q.x - ox, q.y - oy)) continue;
-        stamp(hctx, q, q.x - ox, q.y - oy);
+        if (q) stamp(hctx, q, q.x, q.y - bandTop);
       }
-      /* Everything outside this box is heap that has not changed since it was
-         drawn, so the frame only repairs where the bouncing is: clearing and
-         re-blitting the whole screen every frame costs three megapixels of fill
-         on a phone, and that alone was holding the settle to thirty. */
-      const bx0 = Math.max(0, Math.floor(Math.min(x0, wasX0)));
-      const by0 = Math.max(0, Math.floor(Math.min(y0, wasY0)));
-      const bx1 = Math.min(vw, Math.ceil(Math.max(x1, wasX1)));
-      const by1 = Math.min(vh, Math.ceil(Math.max(y1, wasY1)));
-      if (bx1 > bx0 && by1 > by0) {
-        const w = (bx1 - bx0) * dpr;
-        const h = (by1 - by0) * dpr;
-        ctx.clearRect(bx0 * dpr, by0 * dpr, w, h);
-        ctx.drawImage(heap, bx0 * dpr, by0 * dpr, w, h, bx0 * dpr, by0 * dpr, w, h);
+    }
+
+    /* The layer on screen, cut to the part of it that is on screen: at the top
+       of the page it is entirely below the fold and at the bottom it is a strip
+       across the last third, and blitting the whole band either way is a
+       megapixel of fill for pixels nobody is looking at. */
+    const bx = -ox;
+    const by = bandTop - oy;
+    const jx0 = Math.max(0, bx);
+    const jy0 = Math.max(0, by);
+    const jx1 = Math.min(vw, bx + wall);
+    const jy1 = Math.min(vh, by + bandH);
+    const blit = (): void => {
+      ctx.drawImage(
+        heap,
+        (jx0 - bx) * dpr,
+        (jy0 - by) * dpr,
+        (jx1 - jx0) * dpr,
+        (jy1 - jy0) * dpr,
+        jx0 * dpr,
+        jy0 * dpr,
+        (jx1 - jx0) * dpr,
+        (jy1 - jy0) * dpr,
+      );
+    };
+    const onScreen = hctx !== null && jx1 > jx0 && jy1 > jy0;
+
+    // A scroll moves everything on the canvas, so a repair patch is no good.
+    const rode = ox !== heapX || oy !== heapY;
+    heapX = ox;
+    heapY = oy;
+
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    if (rode) {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+    } else {
+      /* Nothing moved but the letters still in the air, so the frame only
+         repairs where they were and where they are. Clearing and redrawing the
+         whole screen instead costs megapixels of fill on a phone, and that
+         alone was holding the settle to thirty. */
+      const cx0 = Math.max(0, Math.floor(Math.min(x0, wasX0)));
+      const cy0 = Math.max(0, Math.floor(Math.min(y0, wasY0)));
+      const cx1 = Math.min(vw, Math.ceil(Math.max(x1, wasX1)));
+      const cy1 = Math.min(vh, Math.ceil(Math.max(y1, wasY1)));
+      if (cx1 > cx0 && cy1 > cy0) {
+        ctx.clearRect(cx0 * dpr, cy0 * dpr, (cx1 - cx0) * dpr, (cy1 - cy0) * dpr);
+        ctx.save();
+        ctx.beginPath();
+        ctx.rect(cx0 * dpr, cy0 * dpr, (cx1 - cx0) * dpr, (cy1 - cy0) * dpr);
+        ctx.clip();
+      } else {
+        ctx.save();
       }
-      for (const q of parts) {
-        if (q.rest) continue;
-        const px = q.x - ox;
-        const py = q.y - oy;
-        if (off(px, py)) continue;
-        stamp(ctx, q, px, py);
-      }
+      if (onScreen) blit();
+      ctx.restore();
+    }
+    if (rode && onScreen) blit();
+
+    for (const q of active) {
+      const px = q.x - ox;
+      const py = q.y - oy;
+      const r = q.r;
+      if (px < -r || px > vw + r || py < -r || py > vh + r) continue;
+      stamp(ctx, q, px, py);
     }
 
     wasX0 = x0;
@@ -526,35 +647,12 @@ export function drop(): void {
     wasY1 = y1;
   };
 
-  /* The bottom of the document, which is where the fall ends.
-   *
-   * Read live, because the page is not the constant it looks like. Hiding the
-   * type moves nothing - every block keeps its box - but the ride scrolls the
-   * whole document past the viewport in four seconds, and that hydrates every
-   * `client:visible` island on the way down. One of them, the autotyper lab,
-   * renders its terminal in place of the form the server sent and takes 137px
-   * out of a 430 phone as it does. A floor measured once at the keystroke then
-   * sits below the bottom the reader can actually reach, and the heap standing
-   * on it is built partly out of view: measured 138px of it unreachable at 430
-   * and 390, and none at 1440, which is the width where that island is already
-   * hydrated before the egg is armed.
-   *
-   * So the floor is whatever the bottom edge of the document is this frame,
-   * and the heap it is holding up moves with it. */
-  let docWas = document.documentElement.scrollHeight;
-  let floor = docWas - FLOOR_GAP;
-  let bottom = Math.max(0, docWas - window.innerHeight);
-  const wall = document.documentElement.clientWidth;
-  const cols = Math.max(1, Math.ceil(wall / COL));
-  /* Height of the heap above the floor, one entry per column. */
-  const pile = new Float32Array(cols);
-  const deepest = window.innerHeight * PILE_MAX;
-
   let raf = 0;
   let last = 0;
   let clock = 0;
   let cam = sy;
   let camV = 0;
+  let edge = -Infinity;
 
   const step = (now: number): void => {
     if (!live) return;
@@ -564,41 +662,66 @@ export function drop(): void {
     last = now;
     clock += dt * 1000;
 
-    const docH = document.documentElement.scrollHeight;
-    if (docH !== docWas) {
+    /* One read of where the page is, taken before this frame writes to it. */
+    const view = window.scrollY;
+
+    if (docNow !== docWas) {
       /* Letters in mid-air are debris and a hundred px of drift on the way
          down is not observable. The heap is: it has a floor under it and the
          floor has moved, so it goes with it, and the layer holding its pixels
-         is no longer true. */
-      const shift = docH - docWas;
-      docWas = docH;
-      floor += shift;
-      bottom = Math.max(0, docH - window.innerHeight);
-      for (const q of still) q.y += shift;
+         has to be laid down again against the new one. Twice a fall, not per
+         frame. */
+      const move = docNow - docWas;
+      docWas = docNow;
+      floor += move;
+      bottom = Math.max(0, docNow - vh);
+      bandTop = floor - deepest - reach;
+      for (const q of still) q.y += move;
+      if (hctx) {
+        hctx.setTransform(1, 0, 0, 1, 0, 0);
+        hctx.clearRect(0, 0, heap.width, heap.height);
+      }
+      baked = 0;
       heapY = NaN;
     }
 
-    /* The line the floor is giving way along, in document coordinates. Once
-       the ride is over it is the bottom of the document, so the last of the
-       type lets go rather than standing there over the heap. */
-    const edge = cam >= bottom ? floor : cam + window.innerHeight * WAKE;
+    /* The line the floor is giving way along, in document coordinates, taken
+       off where the reader is actually standing rather than off the camera -
+       the two are the same while the ride drives, and when it stops driving
+       the page should still come apart ahead of them. It only ever moves
+       down: scrolling back up puts nobody back together. Reaching the bottom
+       lets everything left go at once, so the last of the type falls rather
+       than standing there over the heap - everything left, not everything down
+       to the floor, because a block can sit below the bottom of the document
+       and one does: the flipped Side B line in the footer is turned about its
+       own middle and its box lands 67px past the end of the page. Cut off at
+       the floor it never let go, it stood over the heap in live text, and the
+       loop it was keeping alive ran a frame forever. */
+    const line = view >= bottom - 1 ? Infinity : view + vh * WAKE;
+    if (line > edge) edge = line;
 
-    while (dissolved < faded.length) {
-      const f = faded[dissolved];
-      if (f && f.y > edge) break;
-      dissolved++;
-      if (f) dissolve(f.el);
+    while (opened < blocks.length) {
+      const b = blocks[opened];
+      if (!b || b.y > edge) break;
+      opened++;
+      /* The letters take over from the element in the same frame the element
+         stops being drawn - the sprites are cut to the boxes the browser laid
+         out, so the swap is pixel for pixel and there is nothing to see. */
+      b.el.style.visibility = 'hidden';
+      shown.push(b.el);
+      for (const q of b.parts) {
+        /* Down the block as well as across the page, so a twelve-line
+           paragraph peels off its own top line first instead of dropping out
+           of the page as a slab. */
+        q.hold = clock + rand(0, HOLD) + (q.y - b.y) * LINE_LAG;
+        active.push(q);
+      }
     }
 
-    let awake = 0;
-    for (const q of parts) {
-      if (q.rest) continue;
-      awake++;
-      if (q.wake >= 0) {
-        if (q.wake > edge) continue;
-        q.wake = -1;
-        q.hold = clock + rand(0, HOLD);
-      }
+    /* Backwards, because a letter that lands is swapped off the end of this. */
+    for (let i = active.length - 1; i >= 0; i--) {
+      const q = active[i];
+      if (!q) continue;
       if (clock < q.hold) continue;
       q.vy += G * dt;
       q.x += q.vx * dt;
@@ -637,19 +760,26 @@ export function drop(): void {
       q.y = surface;
 
       if (q.vy < LAND_V || clock > MAX_MS) {
-        q.rest = true;
         q.vr = 0;
-        awake--;
         still.push(q);
+        const end = active.pop();
+        if (end && i < active.length) active[i] = end;
         /* What this letter adds to the columns beneath it: its ink spread over
            the width it actually covers, so a word lying flat raises a wide
            strip by a little and the same word on its end raises a narrow one
            by a lot. Raising by its height instead builds a heap of mostly air,
            because a turned letter's box is mostly air - and the air stacks
            into a plane of type with open ground underneath it. */
-        const spread = Math.min(q.rh, (q.rw * q.rh * INK) / Math.max(2 * hw, 1));
-        const lift = Math.min(deepest, top + spread);
-        for (let i = c0; i <= c1; i++) if ((pile[i] ?? 0) < lift) pile[i] = lift;
+        const spread = Math.min(q.rh, (q.rw * q.rh * ink) / ((c1 - c0 + 1) * COL));
+        /* Roughened, because a surface built by an exact rule is exactly
+           level, and the type does not fall in a random order - a block goes
+           at once, so all of one size and colour lands on the same instant of
+           a flat surface and rules a line across the page. The smallest grey
+           caption type drew a 10px band the full width of the screen, straight
+           enough to read as a border. The heap ends up the same depth either
+           way; it just has a surface. */
+        const lift = spread * rand(0.3, 1.7);
+        for (let i = c0; i <= c1; i++) pile[i] = Math.min(deepest, (pile[i] ?? 0) + lift);
         continue;
       }
 
@@ -658,6 +788,9 @@ export function drop(): void {
       q.vy = -q.vy * REST;
     }
 
+    slump();
+
+    let at = view;
     if (cam < bottom) {
       camV += G * CAM_G * dt;
       /* The fastest the page can still be going and stop exactly on the
@@ -668,26 +801,25 @@ export function drop(): void {
       /* Instant, because the stylesheet asks for smooth scrolling and a
          smoothed scroll inside a per-frame loop is a fight, not a fall. */
       window.scrollTo({ top: cam, left: sx, behavior: 'instant' });
-      awake++;
+      at = cam;
     }
 
-    paint();
-    raf = awake ? requestAnimationFrame(step) : 0;
+    paint(sx, at);
+    const busy = active.length > 0 || opened < blocks.length || cam < bottom;
+    raf = busy ? requestAnimationFrame(step) : 0;
   };
 
-  paint();
+  paint(sx, sy);
   raf = requestAnimationFrame(step);
 
   const undo = (): void => {
     if (!live) return;
     live = false;
     if (raf) cancelAnimationFrame(raf);
-    for (const t of seals) clearTimeout(t);
+    watch.disconnect();
     canvas.remove();
-    for (const el of [...hidden, ...faded.map((f) => f.el)]) {
+    for (const el of shown) {
       el.style.removeProperty('visibility');
-      el.style.removeProperty('transition');
-      el.style.removeProperty('opacity');
       if (el.getAttribute('style') === '') el.removeAttribute('style');
     }
     window.scrollTo({ top: sy, left: sx, behavior: 'instant' });

--- a/src/scripts/gravity.ts
+++ b/src/scripts/gravity.ts
@@ -4,8 +4,14 @@
  * Every piece of type on the page comes apart into letters, the letters fall
  * the whole height of the document, and the page falls after them to watch
  * them land. It is not on a control and it is not advertised; it is behind ten
- * keys nobody types by accident, and the next thing the reader does puts the
- * page back exactly as it was, including where they were standing.
+ * keys nobody types by accident.
+ *
+ * It does not undo. The ride hands the viewport back the moment the reader
+ * disagrees with it, and after that they are free to scroll the wreckage as
+ * far as it goes - type the wave has not reached yet comes apart as they
+ * arrive at it - but nothing they can do puts a letter back. A reload does,
+ * and only a reload. An egg that tidies itself up the instant it is touched is
+ * an egg nobody gets to look at.
  *
  * ── why a canvas and not the elements themselves
  *
@@ -19,8 +25,9 @@
  * being about how much of it is on the screen, which is bounded by the screen.
  *
  * Nothing in the document moves. The type is hidden where it stands, so every
- * box keeps its size and the page keeps its height and its scroll range, and
- * putting it back is dropping two inline properties and one canvas.
+ * box keeps its size and the page keeps its height and its scroll range - the
+ * reader is scrolling the same document afterwards, with the same anchors and
+ * the same bottom, and only the ink has left it.
  */
 
 /* Blocks of type, not their containers: a paragraph inside a list item is
@@ -72,6 +79,11 @@ const CAM_G = 0.55;
 /* Braked harder than it accelerates, so the ride stops on the pile instead of
    arriving at six thousand pixels a second and hitting a wall. */
 const CAM_BRAKE = 2.2;
+
+/* ms at the start during which the page moving under the camera is the
+   incantation's own doing and not the reader's. The smooth scroll two arrow
+   keys leave running was measured at 220ms; this is that with room. */
+const HANDOFF = 400;
 
 /* Where on the screen the page comes apart, as a fraction of its height.
    Letting the whole document go at once is a fall the reader misses: it all
@@ -174,11 +186,6 @@ interface Style {
   sw: number;
 }
 
-/* Anything the reader does, and it is over. `scroll` is not in the list
-   because the page is about to be scrolled by this file, and a run that
-   cancels itself on its own first frame is not a run. */
-const ENDS = ['keydown', 'pointerdown', 'touchstart', 'wheel', 'resize'] as const;
-
 interface Particle {
   t: string;
   s: number;
@@ -212,6 +219,8 @@ interface Block {
   parts: Particle[];
 }
 
+/* Set once and never cleared, because the floor only gives way once. A second
+   ten keys does nothing; the reload is the way back. */
 let live = false;
 
 /* One measuring context for the whole run, because `measureText` needs a
@@ -421,8 +430,8 @@ export function drop(): void {
     return;
   }
 
-  const vw = window.innerWidth;
-  const vh = window.innerHeight;
+  let vw = window.innerWidth;
+  let vh = window.innerHeight;
   const wall = document.documentElement.clientWidth;
   canvas.width = Math.ceil(vw * dpr);
   canvas.height = Math.ceil(vh * dpr);
@@ -450,6 +459,9 @@ export function drop(): void {
   let bottom = Math.max(0, docNow - vh);
   const watch = new ResizeObserver(() => {
     docNow = document.documentElement.scrollHeight;
+    /* The heap stands on the floor whether or not anything is still moving,
+       so a page that grows under a sleeping loop still has to be answered. */
+    wake();
   });
   watch.observe(document.body);
 
@@ -481,16 +493,31 @@ export function drop(): void {
     }
   };
 
-  /* Nothing counts as scrolled into view while this runs, or the fall marks
-     half the page as already seen and the reader never gets its first look. */
+  /* Nothing counts as scrolled into view while the ride has the viewport, or
+     the fall marks half the page as already seen and the reader never gets
+     their first look at it. */
   document.documentElement.setAttribute('data-fell', '');
+
+  /* Down the moment the ride stops driving - by arriving, or by the reader
+     taking the page off it - because everything after that is the reader
+     moving and the bar and the reveals should read it as such.
+   *
+   * A beat late, not on the frame: the scroll event for the last frame the
+   * ride drove arrives after that frame, and the bar would read the tail of
+   * the ride as the reader. Sections that scrolled past underneath the flag
+   * are held by the observer and offered again the moment it comes down. */
+  let held = true;
+  const release = (): void => {
+    if (!held) return;
+    held = false;
+    window.setTimeout(() => document.documentElement.removeAttribute('data-fell'), 160);
+  };
 
   /* Released and still moving, compacted: a letter that lands is swapped off
      the end of this and never costs a frame again. The alternative is a
      `rest` test against every letter on the page, which at this count is the
      per-frame budget spent on deciding to do nothing. */
   const active: Particle[] = [];
-  const shown: HTMLElement[] = [];
   let opened = 0;
 
   /* A letter that is not moving is stamped once into a layer of its own and
@@ -653,9 +680,41 @@ export function drop(): void {
   let cam = sy;
   let camV = 0;
   let edge = -Infinity;
+  /* Where this loop last put the page, and whether it is still entitled to. */
+  let drove = sy;
+  let driving = true;
+
+  const wake = (): void => {
+    if (!raf) raf = requestAnimationFrame(step);
+  };
+
+  /* The reader has said so out loud. Not a cancel and nothing is read off it
+     but the fact that they want the page back - the same handover the loop
+     makes when it notices the page has moved.
+   *
+   * Both are needed. A wheel is applied whole on the frame it arrives and this
+   * loop writes the position on that same frame, so half the time the write
+   * lands second and the reader's scroll is gone before anything can notice
+   * it - measured at about one flick in two. An event cannot be overwritten.
+   * The other way round, a scrollbar drag and a find bar move the page without
+   * an event this could hear, which is what the position check is for. */
+  const asked = (e: Event): void => {
+    /* Of the keys, only the ones that move a page: someone reaching for a
+       screenshot in the middle of the fall has not asked for anything. */
+    if (e.type === 'keydown') {
+      const k = (e as KeyboardEvent).key;
+      if (!/^(Arrow|Page)/.test(k) && k !== 'Home' && k !== 'End' && k !== ' ') return;
+    }
+    if (!driving) return;
+    driving = false;
+    release();
+  };
+  for (const ev of ['wheel', 'touchstart', 'keydown']) {
+    window.addEventListener(ev, asked, { passive: true, capture: true });
+  }
 
   const step = (now: number): void => {
-    if (!live) return;
+    raf = 0;
     /* Clamped, because a tab that was in the background hands back a delta of
        several seconds and every letter would arrive already buried. */
     const dt = last ? Math.min(1 / 30, (now - last) / 1000) : 1 / 60;
@@ -664,6 +723,30 @@ export function drop(): void {
 
     /* One read of where the page is, taken before this frame writes to it. */
     const view = window.scrollY;
+
+    /* The other half of the handover, and the one that catches the ways of
+       moving a page that fire nothing: the loop knows where it put the page
+       last frame, so the page being anywhere else is the reader, whatever they
+       used to get there. The letters go on falling either way.
+     *
+     * Except at the very start, where the page is somewhere else because of
+     * the incantation. Four of its ten keys are arrows, an arrow key scrolls,
+     * and the stylesheet asks for that scroll to be smooth - so a page typed
+     * at faster than reading speed is still gliding downwards when the last
+     * two keys land, and the ride would read its own summons as a reader who
+     * had changed their mind. The glide cannot be called off: an instant
+     * scrollTo, a smooth one retargeted at the current position, clearing
+     * scroll-behavior and a synthetic wheel event were all measured, and it
+     * runs on to its own target through every one of them. So for the first
+     * fraction of a second the ride goes along with the page instead of
+     * arguing with it, and only then starts holding it to account. */
+    if (driving && Math.abs(view - drove) > 1) {
+      if (clock < HANDOFF) cam = Math.max(cam, view);
+      else {
+        driving = false;
+        release();
+      }
+    }
 
     if (docNow !== docWas) {
       /* Letters in mid-air are debris and a hundred px of drift on the way
@@ -708,7 +791,6 @@ export function drop(): void {
          stops being drawn - the sprites are cut to the boxes the browser laid
          out, so the swap is pixel for pixel and there is nothing to see. */
       b.el.style.visibility = 'hidden';
-      shown.push(b.el);
       for (const q of b.parts) {
         /* Down the block as well as across the page, so a twelve-line
            paragraph peels off its own top line first instead of dropping out
@@ -791,57 +873,61 @@ export function drop(): void {
     slump();
 
     let at = view;
-    if (cam < bottom) {
-      camV += G * CAM_G * dt;
-      /* The fastest the page can still be going and stop exactly on the
-         bottom. Capping to it turns a free fall into an arrival, with no
-         easing curve to pick and no distance left over. */
-      const brake = Math.sqrt(2 * G * CAM_BRAKE * (bottom - cam));
-      cam = Math.min(bottom, cam + Math.min(camV, brake) * dt);
-      /* Instant, because the stylesheet asks for smooth scrolling and a
-         smoothed scroll inside a per-frame loop is a fight, not a fall. */
-      window.scrollTo({ top: cam, left: sx, behavior: 'instant' });
-      at = cam;
+    if (driving) {
+      if (cam >= bottom) {
+        release();
+        driving = false;
+      } else {
+        camV += G * CAM_G * dt;
+        /* The fastest the page can still be going and stop exactly on the
+           bottom. Capping to it turns a free fall into an arrival, with no
+           easing curve to pick and no distance left over. */
+        const brake = Math.sqrt(2 * G * CAM_BRAKE * (bottom - cam));
+        cam = Math.min(bottom, cam + Math.min(camV, brake) * dt);
+        /* Instant, because the stylesheet asks for smooth scrolling and a
+           smoothed scroll inside a per-frame loop is a fight, not a fall. */
+        window.scrollTo({ top: cam, left: sx, behavior: 'instant' });
+        drove = cam;
+        at = cam;
+      }
     }
 
     paint(sx, at);
-    const busy = active.length > 0 || opened < blocks.length || cam < bottom;
-    raf = busy ? requestAnimationFrame(step) : 0;
+
+    /* Asleep is not over. Nothing puts this page back but a reload, so the
+       loop has to be able to stop costing a frame and still be there: the
+       wreckage is on a fixed canvas, so a scroll with nobody drawing would
+       carry the heap along with the screen, and type the wave has not reached
+       yet still has to come apart when the reader scrolls down to it. Both
+       are one woken frame. */
+    const next = blocks[opened];
+    if (active.length > 0 || driving || (next && next.y <= edge)) wake();
+    else release();
   };
+
+  window.addEventListener('scroll', wake, { passive: true });
+
+  /* A resize does not put the page back either, but the overlay is a bitmap
+     cut to the screen it was made for and the browser would stretch the
+     wreckage to fit a new one. The backing store follows the viewport and the
+     frame is drawn again. The heap keeps the width it fell into: a window
+     pulled wider gets bare floor at the edge rather than type dragged
+     sideways to cover it. */
+  window.addEventListener(
+    'resize',
+    () => {
+      vw = window.innerWidth;
+      vh = window.innerHeight;
+      bottom = Math.max(0, docNow - vh);
+      canvas.width = Math.ceil(vw * dpr);
+      canvas.height = Math.ceil(vh * dpr);
+      heapX = NaN;
+      heapY = NaN;
+      wake();
+    },
+    { passive: true },
+  );
 
   paint(sx, sy);
-  raf = requestAnimationFrame(step);
-
-  const undo = (): void => {
-    if (!live) return;
-    live = false;
-    if (raf) cancelAnimationFrame(raf);
-    watch.disconnect();
-    canvas.remove();
-    for (const el of shown) {
-      el.style.removeProperty('visibility');
-      if (el.getAttribute('style') === '') el.removeAttribute('style');
-    }
-    window.scrollTo({ top: sy, left: sx, behavior: 'instant' });
-    /* The nav bar watches scrolling, and the events for the jump home arrive
-       after this returns - as can a second one, because a click that cancels
-       the egg also does whatever a click does, and focusing something scrolls
-       it into view. So the flag comes down on the page going quiet rather than
-       on the next frame, and none of it reads as the reader moving. */
-    let quiet = 0;
-    const rest = (): void => {
-      clearTimeout(quiet);
-      quiet = window.setTimeout(() => {
-        window.removeEventListener('scroll', rest, true);
-        if (!live) document.documentElement.removeAttribute('data-fell');
-      }, 160);
-    };
-    window.addEventListener('scroll', rest, { capture: true, passive: true });
-    rest();
-    for (const type of ENDS) window.removeEventListener(type, undo, true);
-  };
-
-  setTimeout(() => {
-    for (const type of ENDS) window.addEventListener(type, undo, { capture: true, passive: true });
-  }, 0);
+  wake();
 }

--- a/src/scripts/gravity.ts
+++ b/src/scripts/gravity.ts
@@ -26,7 +26,8 @@
 /* Blocks of type, not their containers: a paragraph inside a list item is
    collected through the item rather than twice. */
 const TYPE =
-  'h1, h2, h3, h4, p, li, figcaption, blockquote, dt, dd, .tag, .choice, .nav__links a, .btn';
+  'h1, h2, h3, h4, p, li, figcaption, blockquote, dt, dd, .tag, .choice, ' +
+  '.nav__links a, .nav__brand, .hero__mail, .btn';
 
 /* Review furniture and things that are only there for a screen reader. The
    design lab is not part of the page and the skip link is not on it yet. */
@@ -59,6 +60,17 @@ const HOLD = 150;
 /* A page has a bottom, and the ink stops just short of it rather than
    straddling it. */
 const FLOOR_GAP = 8;
+
+/* The camera is a falling body of its own, not a tracker bolted to the lowest
+   letter. Following the front would put the reader at the bottom of the
+   document inside half a second, because the type down there starts almost on
+   the floor and gets there first; falling with the letters, and slower than
+   they do, is what makes them stream past and away instead. */
+const CAM_G = 0.55;
+
+/* Braked harder than it accelerates, so the ride stops on the pile instead of
+   arriving at six thousand pixels a second and hitting a wall. */
+const CAM_BRAKE = 2.2;
 
 const rand = (lo: number, hi: number): number => lo + Math.random() * (hi - lo);
 
@@ -348,10 +360,13 @@ export function drop(): void {
      not moved and is not going to - every block that left is still holding
      its own box - so this is measured once and stays true. */
   const floor = document.documentElement.scrollHeight - FLOOR_GAP;
+  const bottom = Math.max(0, document.documentElement.scrollHeight - window.innerHeight);
 
   let raf = 0;
   let last = 0;
   let clock = 0;
+  let cam = sy;
+  let camV = 0;
 
   const step = (now: number): void => {
     if (!live) return;
@@ -376,6 +391,19 @@ export function drop(): void {
         q.rest = true;
         awake--;
       }
+    }
+
+    if (cam < bottom) {
+      camV += G * CAM_G * dt;
+      /* The fastest the page can still be going and stop exactly on the
+         bottom. Capping to it turns a free fall into an arrival, with no
+         easing curve to pick and no distance left over. */
+      const brake = Math.sqrt(2 * G * CAM_BRAKE * (bottom - cam));
+      cam = Math.min(bottom, cam + Math.min(camV, brake) * dt);
+      /* Instant, because the stylesheet asks for smooth scrolling and a
+         smoothed scroll inside a per-frame loop is a fight, not a fall. */
+      window.scrollTo({ top: cam, left: sx, behavior: 'instant' });
+      awake++;
     }
 
     paint();

--- a/src/scripts/gravity.ts
+++ b/src/scripts/gravity.ts
@@ -83,6 +83,16 @@ const CAM_G = 0.55;
    arriving at six thousand pixels a second and hitting a wall. */
 const CAM_BRAKE = 2.2;
 
+/* Where on the screen the page comes apart, as a fraction of its height.
+   Letting the whole document go at once is a fall the reader misses: it all
+   falls at the same rate, so it never moves relative to itself, and after the
+   first second there is nothing left above the pile - the ride is two seconds
+   of empty page. Instead the floor gives way at a line two thirds down the
+   screen, and holds together below it. Everything the reader has already
+   passed is falling, everything ahead is still a page, and the wave travels
+   down the document as fast as they do. */
+const WAKE = 0.66;
+
 /* How much of the impact speed a letter keeps. A third gets three bounces out
    of a fall the length of the page and none out of a letter that started near
    the bottom, which is the right answer to both. */
@@ -162,7 +172,9 @@ interface Particle {
   vy: number;
   rot: number;
   vr: number;
-  /* ms after the trigger before this one lets go. */
+  /* The document y this one waits for the reader to reach, then a few ms of
+     scatter on top so a line does not let go as one bar. -1 once it is off. */
+  wake: number;
   hold: number;
   /* Down and done. A resting letter is skipped by the loop, and the loop ends
      when there is nothing left that is not resting. */
@@ -284,14 +296,14 @@ export function drop(): void {
   /* Biggest type first, so the budget is spent on the wordmark and the section
      headings before it reaches the body copy. Everything the budget does not
      reach is still leaving, just by fading. */
-  const blocks: Array<{ el: HTMLElement; size: number }> = [];
+  const blocks: Array<{ el: HTMLElement; size: number; y: number }> = [];
   for (const el of document.querySelectorAll<HTMLElement>(TYPE)) {
     if (el.closest(NOT)) continue;
     if (!el.textContent?.trim()) continue;
     if (blocks.some((b) => b.el.contains(el))) continue;
     const box = el.getBoundingClientRect();
     if (box.width < 2 || box.height < 2) continue;
-    blocks.push({ el, size: parseFloat(getComputedStyle(el).fontSize) || 0 });
+    blocks.push({ el, size: parseFloat(getComputedStyle(el).fontSize) || 0, y: box.top + sy });
   }
   if (!blocks.length) return;
   blocks.sort((a, b) => b.size - a.size);
@@ -301,16 +313,16 @@ export function drop(): void {
   const sprites = new Map<string, Sprite | null>();
   const parts: Particle[] = [];
   const hidden: HTMLElement[] = [];
-  const faded: HTMLElement[] = [];
+  const faded: Array<{ el: HTMLElement; y: number }> = [];
 
-  for (const { el, size } of blocks) {
+  for (const { el, size, y } of blocks) {
     if (parts.length >= CAP) {
-      faded.push(el);
+      faded.push({ el, y });
       continue;
     }
     const cut = pieces(el, size >= LETTERS_ABOVE);
     if (!cut.length || parts.length + cut.length > CAP) {
-      faded.push(el);
+      faded.push({ el, y });
       continue;
     }
     /* The angle the block was already showing, off its own matrix. Type inside
@@ -338,7 +350,8 @@ export function drop(): void {
         vy: rand(-40, 40),
         rot: lean,
         vr: rand(-SPIN, SPIN),
-        hold: rand(0, HOLD),
+        wake: r.top + sy,
+        hold: 0,
         rest: false,
         sp: null,
       });
@@ -368,19 +381,27 @@ export function drop(): void {
   document.documentElement.setAttribute('data-fell', '');
 
   for (const el of hidden) el.style.visibility = 'hidden';
-  for (const el of faded) {
+
+  /* The type the budget did not reach leaves at the same moment the letters
+     beside it do, or the page ahead of the wave has holes in it. */
+  faded.sort((a, b) => a.y - b.y);
+  const seals: number[] = [];
+  let dissolved = 0;
+  const dissolve = (el: HTMLElement): void => {
     /* Typing the code scrolls the page, so some of these are still mid-reveal,
        and a running animation outranks an inline declaration. Whatever they
        were in the middle of arriving from, they have arrived. */
     for (const a of el.getAnimations()) a.cancel();
     el.style.transition = 'opacity 260ms linear';
     el.style.opacity = '0';
-  }
-  /* Once faded, gone for good: opacity is a property animations can win back
-     and visibility, here, is not. */
-  const seal = setTimeout(() => {
-    for (const el of faded) el.style.visibility = 'hidden';
-  }, 300);
+    /* Once faded, gone for good: opacity is a property animations can win back
+       and visibility, here, is not. */
+    seals.push(
+      window.setTimeout(() => {
+        el.style.visibility = 'hidden';
+      }, 300),
+    );
+  };
 
   /* A letter that has stopped never moves again, so it is stamped once into a
      layer of its own and every later frame blits that. Without it the whole
@@ -530,10 +551,27 @@ export function drop(): void {
     last = now;
     clock += dt * 1000;
 
+    /* The line the floor is giving way along, in document coordinates. Once
+       the ride is over it is the bottom of the document, so the last of the
+       type lets go rather than standing there over the heap. */
+    const edge = cam >= bottom ? floor : cam + window.innerHeight * WAKE;
+
+    while (dissolved < faded.length) {
+      const f = faded[dissolved];
+      if (f && f.y > edge) break;
+      dissolved++;
+      if (f) dissolve(f.el);
+    }
+
     let awake = 0;
     for (const q of parts) {
       if (q.rest) continue;
       awake++;
+      if (q.wake >= 0) {
+        if (q.wake > edge) continue;
+        q.wake = -1;
+        q.hold = clock + rand(0, HOLD);
+      }
       if (clock < q.hold) continue;
       q.vy += G * dt;
       q.x += q.vx * dt;
@@ -617,9 +655,9 @@ export function drop(): void {
     if (!live) return;
     live = false;
     if (raf) cancelAnimationFrame(raf);
-    clearTimeout(seal);
+    for (const t of seals) clearTimeout(t);
     canvas.remove();
-    for (const el of [...hidden, ...faded]) {
+    for (const el of [...hidden, ...faded.map((f) => f.el)]) {
       el.style.removeProperty('visibility');
       el.style.removeProperty('transition');
       el.style.removeProperty('opacity');

--- a/src/scripts/gravity.ts
+++ b/src/scripts/gravity.ts
@@ -526,11 +526,24 @@ export function drop(): void {
     wasY1 = y1;
   };
 
-  /* The bottom of the document, which is where the fall ends. The page has
-     not moved and is not going to - every block that left is still holding
-     its own box - so this is measured once and stays true. */
-  const floor = document.documentElement.scrollHeight - FLOOR_GAP;
-  const bottom = Math.max(0, document.documentElement.scrollHeight - window.innerHeight);
+  /* The bottom of the document, which is where the fall ends.
+   *
+   * Read live, because the page is not the constant it looks like. Hiding the
+   * type moves nothing - every block keeps its box - but the ride scrolls the
+   * whole document past the viewport in four seconds, and that hydrates every
+   * `client:visible` island on the way down. One of them, the autotyper lab,
+   * renders its terminal in place of the form the server sent and takes 137px
+   * out of a 430 phone as it does. A floor measured once at the keystroke then
+   * sits below the bottom the reader can actually reach, and the heap standing
+   * on it is built partly out of view: measured 138px of it unreachable at 430
+   * and 390, and none at 1440, which is the width where that island is already
+   * hydrated before the egg is armed.
+   *
+   * So the floor is whatever the bottom edge of the document is this frame,
+   * and the heap it is holding up moves with it. */
+  let docWas = document.documentElement.scrollHeight;
+  let floor = docWas - FLOOR_GAP;
+  let bottom = Math.max(0, docWas - window.innerHeight);
   const wall = document.documentElement.clientWidth;
   const cols = Math.max(1, Math.ceil(wall / COL));
   /* Height of the heap above the floor, one entry per column. */
@@ -550,6 +563,20 @@ export function drop(): void {
     const dt = last ? Math.min(1 / 30, (now - last) / 1000) : 1 / 60;
     last = now;
     clock += dt * 1000;
+
+    const docH = document.documentElement.scrollHeight;
+    if (docH !== docWas) {
+      /* Letters in mid-air are debris and a hundred px of drift on the way
+         down is not observable. The heap is: it has a floor under it and the
+         floor has moved, so it goes with it, and the layer holding its pixels
+         is no longer true. */
+      const shift = docH - docWas;
+      docWas = docH;
+      floor += shift;
+      bottom = Math.max(0, docH - window.innerHeight);
+      for (const q of still) q.y += shift;
+      heapY = NaN;
+    }
 
     /* The line the floor is giving way along, in document coordinates. Once
        the ride is over it is the bottom of the document, so the last of the

--- a/src/scripts/gravity.ts
+++ b/src/scripts/gravity.ts
@@ -512,7 +512,6 @@ export function drop(): void {
     if (raf) cancelAnimationFrame(raf);
     clearTimeout(seal);
     canvas.remove();
-    document.documentElement.removeAttribute('data-fell');
     for (const el of [...hidden, ...faded]) {
       el.style.removeProperty('visibility');
       el.style.removeProperty('transition');
@@ -520,6 +519,12 @@ export function drop(): void {
       if (el.getAttribute('style') === '') el.removeAttribute('style');
     }
     window.scrollTo({ top: sy, left: sx, behavior: 'instant' });
+    /* The nav bar and the reveal observer both watch scrolling, and the events
+       for the jump home arrive after this returns. The flag stays up one more
+       frame so neither of them reads the snap back as the reader moving. */
+    requestAnimationFrame(() => {
+      if (!live) document.documentElement.removeAttribute('data-fell');
+    });
     for (const type of ENDS) window.removeEventListener(type, undo, true);
   };
 

--- a/src/scripts/gravity.ts
+++ b/src/scripts/gravity.ts
@@ -57,9 +57,10 @@ const DRIFT = 46;
 const SPIN = 2.6;
 const HOLD = 150;
 
-/* A page has a bottom, and the ink stops just short of it rather than
-   straddling it. */
-const FLOOR_GAP = 8;
+/* A page has a bottom, and the ink stops short of it rather than straddling
+   it. Wide enough to cover the padding a sprite carries for its stroke and
+   for the ink round letters push past their own line box. */
+const FLOOR_GAP = 22;
 
 /* The camera is a falling body of its own, not a tracker bolted to the lowest
    letter. Following the front would put the reader at the bottom of the
@@ -71,6 +72,48 @@ const CAM_G = 0.55;
 /* Braked harder than it accelerates, so the ride stops on the pile instead of
    arriving at six thousand pixels a second and hitting a wall. */
 const CAM_BRAKE = 2.2;
+
+/* How much of the impact speed a letter keeps. A third gets three bounces out
+   of a fall the length of the page and none out of a letter that started near
+   the bottom, which is the right answer to both. */
+const REST = 0.3;
+
+/* Sideways speed kept through an impact, and the share of the landing speed
+   thrown sideways by it. A hard landing scattering outward is most of what a
+   heap of type settling actually looks like. */
+const DRAG = 0.72;
+const SPLASH = 0.18;
+
+/* The page has edges. Letters that drift off them are letters the reader
+   paid for and did not get to watch land. */
+const WALL = 0.5;
+
+/* Below this, the next bounce would not clear the letter's own height, so it
+   has not bounced - it has landed. */
+const LAND_V = 200;
+
+/* The heap is a height per column of the page rather than letter against
+   letter: two hundred bodies is twenty thousand pairs and this is a hundred
+   and twenty numbers. A letter lands on what the columns it covers are
+   standing at, then raises them by rather less than its own height, because
+   type in a pile interlocks instead of stacking.
+ *
+ * Landing on the highest of those columns is the obvious rule and the wrong
+ * one. It ratchets: one tall column drags every neighbour it touches up with
+ * it, wide pieces couple columns that are nowhere near each other, and two
+ * hundred letters build a tower several screens tall - measured at 3858px on
+ * a 430 phone, where a heap has no business being deeper than a screen. So
+ * the surface is halfway between the highest column and their average, which
+ * lets a letter sink into the dip beside a tall one, and the whole heap is
+ * capped at rather less than a screen. Past the cap the letters pack in
+ * rather than stack up, which is what a heap of paper does anyway. */
+const COL = 12;
+const INK = 0.3;
+const PILE_MAX = 0.3;
+
+/* A backstop, not a design. Nothing should still be moving by here; if
+   something is, it stops being interesting long before it stops moving. */
+const MAX_MS = 9000;
 
 const rand = (lo: number, hi: number): number => lo + Math.random() * (hi - lo);
 
@@ -361,6 +404,11 @@ export function drop(): void {
      its own box - so this is measured once and stays true. */
   const floor = document.documentElement.scrollHeight - FLOOR_GAP;
   const bottom = Math.max(0, document.documentElement.scrollHeight - window.innerHeight);
+  const wall = document.documentElement.clientWidth;
+  const cols = Math.max(1, Math.ceil(wall / COL));
+  /* Height of the heap above the floor, one entry per column. */
+  const pile = new Float32Array(cols);
+  const deepest = window.innerHeight * PILE_MAX;
 
   let raf = 0;
   let last = 0;
@@ -385,12 +433,57 @@ export function drop(): void {
       q.x += q.vx * dt;
       q.y += q.vy * dt;
       q.rot += q.vr * dt;
-      const low = floor - q.rh / 2;
-      if (q.y >= low) {
-        q.y = low;
-        q.rest = true;
-        awake--;
+
+      /* The box the letter covers at the angle it is turning through, which is
+         what has to clear the walls and the heap. A rest computed off the
+         upright box buries a letter that lands on its corner. */
+      const c = Math.abs(Math.cos(q.rot));
+      const s = Math.abs(Math.sin(q.rot));
+      const hw = (q.rw * c + q.rh * s) / 2;
+      const hh = (q.rw * s + q.rh * c) / 2;
+
+      if (q.x < hw) {
+        q.x = hw;
+        q.vx = -q.vx * WALL;
+      } else if (q.x > wall - hw) {
+        q.x = wall - hw;
+        q.vx = -q.vx * WALL;
       }
+
+      const c0 = Math.max(0, ((q.x - hw) / COL) | 0);
+      const c1 = Math.min(cols - 1, ((q.x + hw) / COL) | 0);
+      let high = 0;
+      let sum = 0;
+      for (let i = c0; i <= c1; i++) {
+        const h = pile[i] ?? 0;
+        sum += h;
+        if (h > high) high = h;
+      }
+      const top = (high + sum / (c1 - c0 + 1)) / 2;
+
+      const surface = floor - top - hh;
+      if (q.y < surface) continue;
+      q.y = surface;
+
+      if (q.vy < LAND_V || clock > MAX_MS) {
+        q.rest = true;
+        q.vr = 0;
+        awake--;
+        /* What this letter adds to the columns beneath it: its ink spread over
+           the width it actually covers, so a word lying flat raises a wide
+           strip by a little and the same word on its end raises a narrow one
+           by a lot. Raising by its height instead builds a heap of mostly air,
+           because a turned letter's box is mostly air - and the air stacks
+           into a plane of type with open ground underneath it. */
+        const spread = Math.min(q.rh, (q.rw * q.rh * INK) / Math.max(2 * hw, 1));
+        const lift = Math.min(deepest, top + spread);
+        for (let i = c0; i <= c1; i++) if ((pile[i] ?? 0) < lift) pile[i] = lift;
+        continue;
+      }
+
+      q.vx = q.vx * DRAG + rand(-1, 1) * q.vy * SPLASH;
+      q.vr = -q.vr * 0.45 + rand(-1.2, 1.2);
+      q.vy = -q.vy * REST;
     }
 
     if (cam < bottom) {

--- a/src/scripts/gravity.ts
+++ b/src/scripts/gravity.ts
@@ -99,14 +99,20 @@ const WAKE = 0.66;
    next bounce would not clear its own height, so it has landed rather than
    bounced.
  *
- * These are the frame rate, not the feel. A letter costs nothing on the page
- * and costs a draw every frame from the moment it lets go until the moment it
- * stops, and eight thousand letters all arrive at the floor inside the same
- * two seconds. A third of the impact speed kept is three bounces and about a
- * second and a half of them, which put seven thousand letters on the screen at
- * once and the fall at 19.8fps on a 4x-throttled phone. A sixth is one clear
- * bounce and a settle, which is what a letter of ink landing in a heap of
- * other letters looks like anyway, and it is 30.6fps. */
+ * These are how long it goes on for, not the feel. A letter costs nothing on
+ * the page and costs a draw every frame from the moment it lets go until the
+ * moment it stops, and eight thousand letters all arrive at the floor inside
+ * the same two seconds - so the end of the fall is the expensive part, with
+ * every letter on the page in the same few screens, and the way to pay less
+ * for it is to be in it for less time.
+ *
+ * Measured at 430 with 8904 letters on a 4x-throttled phone, both settings
+ * average about the same through the fall itself - 18fps against 17.4 - but a
+ * sixth of the impact speed kept is one clear bounce and a settle, and it is
+ * over and asleep inside eleven seconds. A third is three bounces, and it is
+ * still putting letters down at fourteen: three more seconds of the part that
+ * runs at six. It also happens to be what a letter of ink landing in a heap of
+ * other letters looks like. */
 const REST = 0.16;
 const LAND_V = 300;
 
@@ -253,8 +259,10 @@ function readStyle(el: Element): Style {
  * back, and frame zero of the fall is the page. And a sprite cut to the line
  * box instead is mostly nothing: a 15px letter in a line of 1.6 leading is a
  * quarter ink and three quarters air, and the air is resampled through the
- * rotation on every frame like anything else. Cutting it out took the fall on
- * a phone at 4x throttle from 15.8fps to 19.8.
+ * rotation on every frame like anything else. Measured at 430 with 8904
+ * letters on a phone at 4x throttle, cutting it out took the whole fall from
+ * 16.1fps to 18, and the first seven seconds of it - before the heap is the
+ * only thing left moving - from 19.4 to 25.1.
  */
 function raster(t: string, st: Style, rw: number, rh: number, dpr: number): Sprite | null {
   if (!gauge) return null;

--- a/src/scripts/gravity.ts
+++ b/src/scripts/gravity.ts
@@ -1,184 +1,330 @@
 /**
  * The floor gives way.
  *
- * Every visible block of type on the screen tips over and falls into a heap at
- * the bottom of the viewport, one after another, the way a bad slide deck used
- * to introduce its bullet points. It is not on a control and it is not
- * advertised; it is behind ten keys nobody types by accident, and the next
- * thing you do puts it back.
+ * Every piece of type on the page comes apart into letters, the letters fall
+ * the whole height of the document, and the page falls after them to watch
+ * them land. It is not on a control and it is not advertised; it is behind ten
+ * keys nobody types by accident, and the next thing the reader does puts the
+ * page back exactly as it was, including where they were standing.
  *
- * Nothing here moves anything. Every element keeps its box and its place in the
- * document and is drawn somewhere else by a transform, so the page underneath
- * is not relaid out, the scroll position does not move, and putting it back is
- * cancelling the animations rather than undoing a change.
+ * ── why a canvas and not the elements themselves
  *
- * Where each block lands is three questions, and they have three different
- * answers. Where it should go is about the type, so it is asked of the ink
- * rather than of the box, which on this page is often a grid cell many times
- * taller. How far it may go before something cuts it in half is asked of the
- * nearest ancestor that hides its overflow. And how far it may go before the
- * page grows a scrollbar is asked of the document, because a page that grows
- * one has both moved under the reader and fired the scroll event that puts
- * everything back a frame after it left.
+ * The previous version of this animated the elements in place, which is the
+ * cheap way to move twenty blocks and the wrong way to move two hundred
+ * letters: each one is a separate style invalidation and a separate raster of
+ * live text, every frame, and a phone at 4x CPU cannot pay that. Here each
+ * letter is drawn once into a small bitmap at the size and weight it already
+ * had, and every frame after that is `drawImage` into one fixed canvas. The
+ * per-frame cost stops being about how much type is on the page and starts
+ * being about how much of it is on the screen, which is bounded by the screen.
+ *
+ * Nothing in the document moves. The type is hidden where it stands, so every
+ * box keeps its size and the page keeps its height and its scroll range, and
+ * putting it back is dropping two inline properties and one canvas.
  */
 
-/* Blocks of type, not their containers: a paragraph inside a list item falls
-   with the item rather than out of it, which the ancestor test below enforces. */
-const TYPE = 'h1, h2, h3, h4, p, li, figcaption, blockquote, dt, dd, .tag, .choice';
+/* Blocks of type, not their containers: a paragraph inside a list item is
+   collected through the item rather than twice. */
+const TYPE =
+  'h1, h2, h3, h4, p, li, figcaption, blockquote, dt, dd, .tag, .choice, .nav__links a, .btn';
 
 /* Review furniture and things that are only there for a screen reader. The
    design lab is not part of the page and the skip link is not on it yet. */
 const NOT = '[data-lab], .inspect-bar, .sr, .skip, [hidden]';
 
-/* Sixty is more than fills any viewport this page has and cheap enough that
-   the whole heap stays on the compositor. */
-const CAP = 60;
+/* The whole document's type is far more than this. What the cap buys is a
+   per-frame draw count that a 4x-throttled phone can hold at 60, so the type
+   that does not fit the budget leaves by fading rather than by janking. The
+   sort below spends the budget on the biggest type on the page, which is the
+   type worth watching fall. */
+const CAP = 240;
 
-const FALL = 620;
-const STAGGER = 18;
-const TILT = 10;
+/* Above this, a block comes apart into letters; below it, into words. Word
+   pieces of body copy read as debris at a distance and cost a fifth as much
+   as the letters would. */
+const LETTERS_ABOVE = 26;
 
-/* Resize is in the list because the landing spots were measured against a
-   viewport that no longer exists, not because a reader asked for the page
-   back. Either way it is the same restore. */
-const ENDS = ['keydown', 'pointerdown', 'touchstart', 'wheel', 'scroll', 'resize'] as const;
+/* A letter never drawn is a bitmap never made, so the raster happens the first
+   frame a letter is on screen rather than all at once behind the keystroke. */
+interface Sprite {
+  c: HTMLCanvasElement;
+  w: number;
+  h: number;
+}
 
-const rand = (lo: number, hi: number): number => lo + Math.random() * (hi - lo);
+interface Style {
+  font: string;
+  size: number;
+  fill: string;
+  stroke: string;
+  sw: number;
+}
 
-/* Where the type actually is, which is not where the element is. Half the
-   blocks on this page sit in grid cells taller than their one line of text -
-   a date label in a 584px row - and measured by their border box they hardly
-   move, because the bottom of the box is already near the floor while the ink
-   is still up at the ceiling. A range over the contents gives the line boxes. */
-const ink = (el: HTMLElement): DOMRect => {
-  const r = document.createRange();
-  r.selectNodeContents(el);
-  const box = r.getBoundingClientRect();
-  r.detach();
-  return box.width && box.height ? box : el.getBoundingClientRect();
-};
+/* Anything the reader does, and it is over. `scroll` is not in the list
+   because the page is about to be scrolled by this file, and a run that
+   cancels itself on its own first frame is not a run. */
+const ENDS = ['keydown', 'pointerdown', 'touchstart', 'wheel', 'resize'] as const;
 
-/* How far down this particular block can go before something cuts it in half.
-   The hero hides its overflow so its light stays inside the panel, and type
-   dropped to the bottom of the screen from inside it arrives sliced through
-   the middle of a line. Piling on the floor of the panel it belongs to reads
-   as deliberate; piling half an inch below a hard edge does not. */
-const clipped = (el: HTMLElement, vh: number): number => {
-  let floor = vh;
-  for (let n = el.parentElement; n && n !== document.body; n = n.parentElement) {
-    if (getComputedStyle(n).overflow !== 'visible')
-      floor = Math.min(floor, n.getBoundingClientRect().bottom);
-  }
-  return floor;
-};
+interface Particle {
+  t: string;
+  s: number;
+  /* Centre rather than corner: the letters spin, and a centre is the one point
+     on a rotating sprite that does not move when it turns. */
+  x: number;
+  y: number;
+  /* The box the browser laid this text out in, which the sprite is cut to. */
+  rw: number;
+  rh: number;
+  vx: number;
+  vy: number;
+  rot: number;
+  vr: number;
+  sp: Sprite | null;
+}
 
 let live = false;
+
+/* One measuring context for the whole run, because `measureText` needs a
+   context and making one per letter would make two hundred of them. */
+let gauge: CanvasRenderingContext2D | null = null;
+
+const styleKey = (s: Style): string => `${s.font}|${s.fill}|${s.stroke}|${s.sw}`;
+
+function readStyle(el: Element): Style {
+  const cs = getComputedStyle(el);
+  return {
+    font: `${cs.fontStyle} ${cs.fontWeight} ${cs.fontSize} / 1 ${cs.fontFamily}`,
+    size: parseFloat(cs.fontSize) || 16,
+    fill: cs.color,
+    /* The outlined line of the wordmark is a stroke over a transparent fill,
+       so both halves are read and both are drawn. */
+    stroke: cs.webkitTextStrokeColor || cs.color,
+    sw: parseFloat(cs.webkitTextStrokeWidth) || 0,
+  };
+}
+
+/**
+ * The bitmap for one piece of text in one style, made once and kept.
+ *
+ * It is cut to the box the browser gave that text - the advance width and the
+ * line box, not the ink - and the glyph is drawn inside it on the baseline the
+ * browser would have used. That is what makes frame zero of the fall identical
+ * to the page: a sprite centred on its own ink instead would shift every
+ * letter by its side bearing, which is invisible on one letter and reads as
+ * loose, drunk spacing across a headline.
+ */
+function raster(t: string, st: Style, rw: number, rh: number, dpr: number): Sprite | null {
+  if (!gauge) return null;
+  gauge.font = st.font;
+  const m = gauge.measureText(t);
+  const asc = m.fontBoundingBoxAscent || m.actualBoundingBoxAscent || st.size * 0.8;
+  const desc = m.fontBoundingBoxDescent || m.actualBoundingBoxDescent || st.size * 0.2;
+  /* Room for the stroke, which is drawn centred on the glyph edge and so
+     hangs half its width outside the metrics, and for ink that overshoots the
+     line box, which round letters do at every size. */
+  const pad = Math.ceil(st.sw) + 4;
+  const w = Math.ceil(rw) + pad * 2;
+  const h = Math.ceil(rh) + pad * 2;
+  if (w < 2 || h < 2 || w > 2000 || h > 2000) return null;
+  /* Half-leading above, then the ascent: where the baseline sits inside a line
+     box is the one thing the range rect does not tell you. */
+  const base = pad + (rh - (asc + desc)) / 2 + asc;
+
+  const c = document.createElement('canvas');
+  c.width = Math.ceil(w * dpr);
+  c.height = Math.ceil(h * dpr);
+  const ctx = c.getContext('2d');
+  if (!ctx) return null;
+  ctx.scale(dpr, dpr);
+  ctx.font = st.font;
+  ctx.textBaseline = 'alphabetic';
+  if (st.sw > 0) {
+    ctx.lineWidth = st.sw;
+    ctx.strokeStyle = st.stroke;
+    ctx.strokeText(t, pad, base);
+  }
+  ctx.fillStyle = st.fill;
+  ctx.fillText(t, pad, base);
+  return { c, w, h };
+}
+
+/**
+ * One element's type, cut into pieces with a box each.
+ *
+ * The style is read off each text node's own parent rather than off the block,
+ * because the two lines of the wordmark are one h1 and only one of them is
+ * outlined.
+ */
+function pieces(el: HTMLElement, byLetter: boolean): Array<{ t: string; r: DOMRect; p: Element }> {
+  const out: Array<{ t: string; r: DOMRect; p: Element }> = [];
+  const walk = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+  const range = document.createRange();
+  for (let n = walk.nextNode(); n; n = walk.nextNode()) {
+    const data = n.nodeValue ?? '';
+    if (!data.trim()) continue;
+    const p = n.parentElement;
+    if (!p || p.closest(NOT)) continue;
+    const re = byLetter ? /\S/g : /\S+/g;
+    for (let m = re.exec(data); m; m = re.exec(data)) {
+      range.setStart(n, m.index);
+      range.setEnd(n, m.index + m[0].length);
+      const r = range.getBoundingClientRect();
+      if (r.width < 1 || r.height < 1) continue;
+      out.push({ t: m[0], r, p });
+    }
+  }
+  return out;
+}
 
 export function drop(): void {
   if (live) return;
 
-  const vw = window.innerWidth;
-  const vh = window.innerHeight;
+  const dpr = Math.min(2, window.devicePixelRatio || 1);
+  const sx = window.scrollX;
+  const sy = window.scrollY;
 
-  const docH = document.documentElement.scrollHeight;
-  const room = docH - window.scrollY;
+  gauge = document.createElement('canvas').getContext('2d');
+  if (!gauge) return;
 
-  const picked: { el: HTMLElement; r: DOMRect; outer: DOMRect; floor: number }[] = [];
+  /* Biggest type first, so the budget is spent on the wordmark and the section
+     headings before it reaches the body copy. Everything the budget does not
+     reach is still leaving, just by fading. */
+  const blocks: Array<{ el: HTMLElement; size: number }> = [];
   for (const el of document.querySelectorAll<HTMLElement>(TYPE)) {
-    if (picked.length >= CAP) break;
     if (el.closest(NOT)) continue;
     if (!el.textContent?.trim()) continue;
-    if (picked.some((p) => p.el.contains(el))) continue;
-    const outer = el.getBoundingClientRect();
-    if (outer.bottom <= 0 || outer.top >= vh) continue;
-    const r = ink(el);
-    if (r.width < 8 || r.height < 8 || r.width > vw) continue;
-    picked.push({ el, r, outer, floor: clipped(el, vh) });
+    if (blocks.some((b) => b.el.contains(el))) continue;
+    const box = el.getBoundingClientRect();
+    if (box.width < 2 || box.height < 2) continue;
+    blocks.push({ el, size: parseFloat(getComputedStyle(el).fontSize) || 0 });
   }
-  if (!picked.length) return;
+  if (!blocks.length) return;
+  blocks.sort((a, b) => b.size - a.size);
+
+  const styles: Style[] = [];
+  const index = new Map<string, number>();
+  const sprites = new Map<string, Sprite | null>();
+  const parts: Particle[] = [];
+  const hidden: HTMLElement[] = [];
+  const faded: HTMLElement[] = [];
+
+  for (const { el, size } of blocks) {
+    if (parts.length >= CAP) {
+      faded.push(el);
+      continue;
+    }
+    const cut = pieces(el, size >= LETTERS_ABOVE);
+    if (!cut.length || parts.length + cut.length > CAP) {
+      faded.push(el);
+      continue;
+    }
+    /* The angle the block was already showing, off its own matrix. Type inside
+       a turned block is drawn upright, so it is set down at that angle instead
+       and the wordmark comes apart along the tilt it had rather than snapping
+       level first. */
+    const m = new DOMMatrixReadOnly(getComputedStyle(el).transform);
+    const lean = Math.atan2(m.b, m.a);
+    for (const { t, r, p } of cut) {
+      const st = readStyle(p);
+      const key = styleKey(st);
+      let s = index.get(key);
+      if (s === undefined) {
+        s = styles.push(st) - 1;
+        index.set(key, s);
+      }
+      parts.push({
+        t,
+        s,
+        x: r.left + sx + r.width / 2,
+        y: r.top + sy + r.height / 2,
+        rw: r.width,
+        rh: r.height,
+        vx: 0,
+        vy: 0,
+        rot: lean,
+        vr: 0,
+        sp: null,
+      });
+    }
+    hidden.push(el);
+  }
+  if (!parts.length) return;
 
   live = true;
-  const anims: Animation[] = [];
 
-  picked.forEach(({ el, r, outer, floor }, i) => {
-    /* Whatever the stylesheet already had on it, kept underneath: the drop is
-       composed onto the element's own transform rather than replacing it, or
-       the wordmark would straighten up on its way down. */
-    const own = getComputedStyle(el).transform;
-    const base = own === 'none' ? '' : ` ${own}`;
+  const canvas = document.createElement('canvas');
+  canvas.setAttribute('aria-hidden', 'true');
+  canvas.style.cssText =
+    'position:fixed;inset:0;width:100%;height:100%;pointer-events:none;z-index:80';
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    live = false;
+    return;
+  }
 
-    const rot = rand(-TILT, TILT);
+  canvas.width = Math.ceil(window.innerWidth * dpr);
+  canvas.height = Math.ceil(window.innerHeight * dpr);
+  document.body.appendChild(canvas);
 
-    /* A rotation swings the far end of a wide block a long way, and the pivot
-       is not always the centre, so the room it needs is the whole span rather
-       than half of it. Reserving it here is what keeps the heap inside the
-       viewport once everything has turned. */
-    const swing = Math.abs(Math.sin((rot * Math.PI) / 180));
+  for (const el of hidden) el.style.visibility = 'hidden';
+  for (const el of faded) {
+    el.style.transition = 'opacity 260ms linear';
+    el.style.opacity = '0';
+  }
 
-    /* Two boxes, two jobs. Where it should land is a question about the type,
-       so it is asked of the ink. How far it may go is a question about what
-       the page will do afterwards, and a transform drags the whole element
-       box with it: past the right edge or past the end of the document and
-       the scrollable area grows, which moves the page under the reader and
-       fires the scroll that ends the egg a frame after it began. */
-    const wantY = floor - 8 - rand(0, 60) - swing * r.width - r.bottom;
-    const roomDown = Math.max(0, room - outer.bottom - swing * outer.width);
+  const paint = (): void => {
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    const ox = window.scrollX;
+    const oy = window.scrollY;
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
 
-    /* Not everything gets to land. A block already lying across the bottom edge
-       has no floor left below it, and left standing while the rest of the page
-       falls it reads as one the effect missed. It goes over the edge instead:
-       a shove down and out, and the only property here that is not a transform,
-       which is as cheap as one. */
-    const land = wantY >= 0 && wantY <= roomDown;
-    const dy = land ? wantY : Math.min(roomDown, Math.max(0, floor - r.top + 40));
-    const end = land ? 1 : 0;
+    for (const q of parts) {
+      const px = q.x - ox;
+      const py = q.y - oy;
+      /* Culled against the screen rather than against its own box, which is
+         not known until the bitmap exists. The margin is generous enough to
+         cover the biggest letter on the page turned on its corner. */
+      if (px < -400 || px > vw + 400 || py < -400 || py > vh + 400) continue;
+      if (!q.sp) {
+        const key = `${q.s}:${q.t}`;
+        let sp = sprites.get(key);
+        if (sp === undefined) {
+          const st = styles[q.s];
+          sp = st ? raster(q.t, st, q.rw, q.rh, dpr) : null;
+          sprites.set(key, sp);
+        }
+        if (!sp) continue;
+        q.sp = sp;
+      }
+      const { c, w, h } = q.sp;
+      const cos = Math.cos(q.rot);
+      const sin = Math.sin(q.rot);
+      ctx.setTransform(cos * dpr, sin * dpr, -sin * dpr, cos * dpr, px * dpr, py * dpr);
+      ctx.drawImage(c, -w / 2, -h / 2, w, h);
+    }
+  };
 
-    /* Drift towards the middle, then back inside the edges. A block with no
-       room left after its own overhang keeps the column it is in. */
-    const padX = swing * outer.height;
-    const lo = padX - outer.left;
-    const hi = vw - padX - outer.right;
-    const drift = vw / 2 + rand(-vw * 0.2, vw * 0.2) - (r.left + r.width / 2);
-    const dx = lo > hi ? 0 : Math.min(Math.max(drift, lo), hi);
-
-    const at = (y: number, deg: number): string =>
-      `translate3d(${dx.toFixed(1)}px, ${y.toFixed(1)}px, 0) rotate(${deg.toFixed(2)}deg)${base}`;
-
-    /* Down, a short bump past where it lands, then a settle. */
-    anims.push(
-      el.animate(
-        [
-          { offset: 0, transform: own, opacity: 1, easing: 'cubic-bezier(0.5, 0, 0.9, 0.35)' },
-          {
-            offset: 0.82,
-            transform: at(dy + 9, rot * 1.12),
-            opacity: land ? 1 : 0.3,
-            easing: 'cubic-bezier(0.2, 0.9, 0.3, 1)',
-          },
-          { offset: 1, transform: at(dy, rot), opacity: end },
-        ],
-        { duration: FALL, delay: i * STAGGER + rand(0, 40), fill: 'forwards' },
-      ),
-    );
-
-    /* A link in the heap is still a link, and a click on it would navigate on
-       the way to putting the page back. Nothing in the pile is clickable. */
-    el.style.pointerEvents = 'none';
-  });
+  paint();
 
   const undo = (): void => {
     if (!live) return;
     live = false;
-    for (const a of anims) a.cancel();
-    for (const { el } of picked) {
-      el.style.pointerEvents = '';
+    canvas.remove();
+    for (const el of hidden) {
+      el.style.removeProperty('visibility');
       if (el.getAttribute('style') === '') el.removeAttribute('style');
     }
+    for (const el of faded) {
+      el.style.removeProperty('transition');
+      el.style.removeProperty('opacity');
+      if (el.getAttribute('style') === '') el.removeAttribute('style');
+    }
+    window.scrollTo({ top: sy, left: sx, behavior: 'instant' });
     for (const type of ENDS) window.removeEventListener(type, undo, true);
   };
 
-  /* Anything at all, and it is over. Attached a task late so the keystroke that
-     started this is not also the one that ends it. */
   setTimeout(() => {
     for (const type of ENDS) window.addEventListener(type, undo, { capture: true, passive: true });
   }, 0);

--- a/src/scripts/motion.ts
+++ b/src/scripts/motion.ts
@@ -53,6 +53,11 @@ function installReveals(): void {
 
   const ms = duration('--dur-3', 620);
 
+  /* Arrived while the egg had the page. An observer does not repeat itself for
+     something that never stopped intersecting, so these are held and offered
+     again once it lets go, or they keep their first look forever. */
+  const missed = new Set<Element>();
+
   const io = new IntersectionObserver(
     (entries) => {
       for (const entry of entries) {
@@ -61,9 +66,13 @@ function installReveals(): void {
            Everything it sweeps past would arrive to an empty room and stay
            marked as arrived, so for as long as it is running nothing counts as
            seen and these elements keep their first look for later. */
-        if (document.documentElement.hasAttribute('data-fell')) continue;
+        if (document.documentElement.hasAttribute('data-fell')) {
+          missed.add(entry.target);
+          continue;
+        }
         const el = entry.target as HTMLElement;
         io.unobserve(el);
+        missed.delete(el);
         el.classList.add('in');
         el.animate(frames, { duration: ms, easing: 'linear', fill: 'none' });
       }
@@ -72,6 +81,16 @@ function installReveals(): void {
   );
 
   targets.forEach((el) => io.observe(el));
+
+  new MutationObserver(() => {
+    if (document.documentElement.hasAttribute('data-fell') || !missed.size) return;
+    // Re-observing re-delivers, which is the only way to ask an observer again.
+    for (const el of missed) {
+      io.unobserve(el);
+      io.observe(el);
+    }
+    missed.clear();
+  }).observe(document.documentElement, { attributeFilter: ['data-fell'] });
 }
 
 /* ── Nav: current section ────────────────────────────────────────────── */

--- a/src/scripts/motion.ts
+++ b/src/scripts/motion.ts
@@ -157,6 +157,10 @@ function installNav(): void {
     if (Math.abs(dy) < 4) return;
     lastY = y;
 
+    /* The egg drives the viewport the length of the document and then snaps it
+       back. None of that is the reader scrolling, so the bar keeps the state
+       they left it in and picks up again from wherever the snap put them. */
+    if (document.documentElement.hasAttribute('data-fell')) return;
     if (holding) {
       hold();
       header.dataset.hidden = 'false';

--- a/src/scripts/motion.ts
+++ b/src/scripts/motion.ts
@@ -57,6 +57,11 @@ function installReveals(): void {
     (entries) => {
       for (const entry of entries) {
         if (!entry.isIntersecting) continue;
+        /* The egg drags the viewport down the whole document in three seconds.
+           Everything it sweeps past would arrive to an empty room and stay
+           marked as arrived, so for as long as it is running nothing counts as
+           seen and these elements keep their first look for later. */
+        if (document.documentElement.hasAttribute('data-fell')) continue;
         const el = entry.target as HTMLElement;
         io.unobserve(el);
         el.classList.add('in');

--- a/src/scripts/motion.ts
+++ b/src/scripts/motion.ts
@@ -53,9 +53,11 @@ function installReveals(): void {
 
   const ms = duration('--dur-3', 620);
 
-  /* Arrived while the egg had the page. An observer does not repeat itself for
-     something that never stopped intersecting, so these are held and offered
-     again once it lets go, or they keep their first look forever. */
+  /* Arrived while the ride had the page. An observer does not repeat itself
+     for something that never stopped intersecting, so these are held and
+     offered again once it lets go, or they keep their first look forever -
+     which matters more now that the reader is left down in the wreckage with
+     the whole page still to scroll back through. */
   const missed = new Set<Element>();
 
   const io = new IntersectionObserver(
@@ -176,9 +178,9 @@ function installNav(): void {
     if (Math.abs(dy) < 4) return;
     lastY = y;
 
-    /* The egg drives the viewport the length of the document and then snaps it
-       back. None of that is the reader scrolling, so the bar keeps the state
-       they left it in and picks up again from wherever the snap put them. */
+    /* The egg drives the viewport the length of the document. None of that is
+       the reader scrolling, so the bar keeps the state they left it in and
+       picks up again from wherever the ride ended. */
     if (document.documentElement.hasAttribute('data-fell')) return;
     if (holding) {
       hold();


### PR DESCRIPTION
## Summary

Adds a Konami-code easter egg to the portfolio: every letter on the page comes apart and falls, under real gravity, to the true bottom of the document, with the viewport riding down after them to watch them land. The letters bounce, scatter, and heap into dunes with an angle of repose. It does not undo - a reload is the only way back.

Thirteen commits, each one a working state. Nothing on the page changes until the ten keys are typed, and nothing is left behind that alters layout: the type is hidden where it stands, so every box keeps its size and the document keeps its height, its anchors and its scroll range.

Two risks worth naming.

**It costs frames while it runs.** At a 4x CPU throttle the fall averages 18fps at 430 and 15.6fps at 1440, with a trough near 6fps in the endgame where every letter is inside a few screens. Unthrottled it sits near 8ms a frame at both widths. It is an egg behind ten keys, so nobody meets it by accident, and the loop sleeps the moment nothing is moving - but it is not free, and a genuinely slow phone will show it. There is no silent cap: every letter falls on every device.

**It is irreversible without a reload.** That is deliberate. An earlier version restored the page on the next input, which meant anyone who touched anything in the first second never got to see it.

Reduced-motion users get nothing at all - the egg is not installed.

## Changes

**The egg** - `src/scripts/gravity.ts`, new.

- Every visible text node is split on `/\S/g` into one particle per non-whitespace character. No word chunking, no cap, no cap-dropping of body text. 8904 particles at 430, 13016 at 1440.
- Each letter is rastered once into a small bitmap cut to its own ink, not to its line box, and carries the offset back to where the browser laid it out - so frame zero of the fall is pixel-identical to the page. Every frame after that is `drawImage` into one fixed overlay canvas, which makes the per-frame cost a function of what is on screen rather than what is in the document.
- The floor gives way at a line two-thirds down the viewport and the wave travels down the document as fast as the reader does, so type ahead of them is still a page. Type the wave never reached comes apart when they scroll to it later.
- The floor itself is the live document bottom. A `ResizeObserver` on `documentElement` re-reads it; the heap's floor, its bitmap layer, and the camera's target all move with it.
- The heap is a height per column rather than letter-against-letter collision. Each letter deposits its own ink divided across the columns it covers, and any column overhanging its neighbour past a 9 degree angle of repose sheds half the excess sideways.
- The camera is its own falling body, braked harder than it accelerates, so it stops on the pile rather than into a wall.
- It hands the viewport back the moment the reader disagrees, via two independent signals - `wheel`/`touchstart`/scroll-keys, and the loop noticing the page is somewhere it did not put it. The first 400ms are exempt from the position check, because four of the Konami keys are arrows and `scroll-behavior: smooth` leaves a scroll running that cannot be cancelled.

**Nav and reveals** - `src/scripts/motion.ts`. A `data-fell` flag on `documentElement` while the ride has the viewport, so the nav bar does not read the ride as the reader scrolling, and the reveal observer holds sections that scrolled past underneath it and offers them again afterwards.

**Verify harness** - `scripts/verify.mjs`. Two pre-existing flakes fixed on the way: the framed-game check demanded 29fps from a headless canvas that measures anywhere between 13 and 93, and `heroContrast` read the hero frame and its type in two separate `page.evaluate` calls, so a focus left inside an opened project card could scroll the page between them and kill the whole pass on a destructure of an empty map entry.

## Output

```
$ npm run lint
eslint . && prettier --check . && node scripts/check-mq.mjs
All matched files use Prettier code style!
check-mq: no range-syntax media queries in src, dist

$ npm run build:lab && node scripts/verify.mjs
206 ok, 0 failures
PASS - no failures
```

Particle count and frame rate, measured at a 4x CPU throttle in fixed windows timed from the keypress:

| viewport | particles | blocks | whole fall | first 7s | endgame | asleep by |
|---|---|---|---|---|---|---|
| 430 | 8904 | 173 | 18.0 fps | 25.1 fps | ~6 fps | 11s |
| 1440 | 13016 | 302 | 15.6 fps | 10.2 fps | ~5.3 fps | still settling at 14s |

Nothing is degraded or capped on either. Unthrottled, both sit near 8ms a frame.

The floor lands on the exact document bottom at both widths:

```
430   landed at 11420 of 11420
1440  landed at 11754 of 11754
```

A 35-assertion behavioural harness covering the contract, green on three consecutive runs:

```
PASS  430 reduced-motion: no overlay, no hidden type, no flag
PASS  1440 reduced-motion: page did not scroll itself  (y=900)
PASS  sonia egg unaffected  (SoniaUppal)
PASS  wheel / key / click / touch / resize / konami again: no type came back
PASS  yield: the ride was driving when it was interrupted  (y=636)
PASS  yield: the page stayed where the reader put it  (66 then 66)
PASS  yield: the fall carried on regardless  (33 blocks down)
PASS  wave: scrolling down drops what it reaches  (17 then 124)
PASS  wave: and the rest of it at the bottom  (124 then 302)
PASS  flag: up while the ride has the page
PASS  flag: down once the ride is over
PASS  flag: the reveals it held were offered again  (0 then 4)
PASS  pinned: the heap was on screen at the bottom  (row 574)
PASS  pinned: scrolling up 200 moved it down 200  (200)
PASS  reload: overlay, hidden type and flag all gone
PASS  reload: markup identical to before the egg  (140703 vs 140703 chars)

all good
```

That last one is the guarantee that matters most: after a reload the page's markup is byte-identical to what it was before the egg ran.

Every reveal still arrives - `22/22 revealed` at 430 and 1440, with and without the egg.
