### PR TITLE
[portfolio] Add Blockhold and Cubit to the Playground

### DIFF
--- a/src/data/content.ts
+++ b/src/data/content.ts
@@ -645,7 +645,7 @@ export const playground = {
      in this repository is dated 10 February 2015, so eleven years is a fact
      git will hand back to anyone who asks it. */
   statement: 'Eleven years of this, and the oldest ones still run.',
-  prose: ['Here are three of the oldest, running in the page, and the newest, which wants a screen of its own. Go ahead.'],
+  prose: ['Three of the oldest run here. The two newest need screens of their own. Go ahead.'],
   items: [
     {
       yr: 'c. 2019',
@@ -680,8 +680,17 @@ export const playground = {
       href: '/blockhold/',
       status: 'live' as Status,
       statusLabel: 'Runs',
-      what: 'A voxel tower defense: five maps, three heroes, road traps, a shard economy, an endless mode. There is no asset file anywhere in it - every model is boxes placed in code, every sound is synthesized at play time. Built this August, pair-working with agents.',
+      what: 'A voxel tower defense: five maps, three heroes, road traps, a shard economy, an endless mode. There is no asset file anywhere in it - every model is boxes placed in code, every sound is synthesized at play time. I built it this August, working with agents.',
       k: 'three.js · TypeScript · PWA',
+    },
+    {
+      yr: '2026',
+      name: 'Cubit',
+      href: '/cubit/',
+      status: 'live' as Status,
+      statusLabel: 'Runs',
+      what: '2048, cubed: slide and merge tiles inside a 3x3x3 cube, across six directions instead of four. Vanilla JS with a vendored three.js, bundled into a single self-contained HTML file.',
+      k: 'Vanilla JS · three.js',
     },
   ],
 } as const;

--- a/src/data/content.ts
+++ b/src/data/content.ts
@@ -645,7 +645,7 @@ export const playground = {
      in this repository is dated 10 February 2015, so eleven years is a fact
      git will hand back to anyone who asks it. */
   statement: 'Eleven years of this, and the oldest ones still run.',
-  prose: ['Here are three of the oldest, running in the page. Go ahead.'],
+  prose: ['Here are three of the oldest, running in the page, and the newest, which wants a screen of its own. Go ahead.'],
   items: [
     {
       yr: 'c. 2019',
@@ -673,6 +673,15 @@ export const playground = {
       statusLabel: 'Repaired',
       what: 'Doodle Jump in three dimensions, built while I was learning three.js. Its keyboard library vanished along with a CDN, so the dependencies now live in the repo.',
       k: 'three.js r70 · vendored deps',
+    },
+    {
+      yr: '2026',
+      name: 'Blockhold',
+      href: '/blockhold/',
+      status: 'live' as Status,
+      statusLabel: 'Runs',
+      what: 'A voxel tower defense: five maps, three heroes, road traps, a shard economy, an endless mode. There is no asset file anywhere in it - every model is boxes placed in code, every sound is synthesized at play time. Built this August, pair-working with agents.',
+      k: 'three.js · TypeScript · PWA',
     },
   ],
 } as const;

--- a/src/pages/alternate.astro
+++ b/src/pages/alternate.astro
@@ -527,6 +527,30 @@ const canonical = new URL('/alternate/', site.url).href;
                 note="Vendored three.js r70, served from its original URL"
               />
             </article>
+
+            {
+              /* The newest two do not run inline on either route: full games
+                want the whole screen and a save file, so here too they are
+                doors rather than windows. */
+            }
+            {
+              playground.items.slice(3).map((it) => (
+                <article class="lab2" data-reveal>
+                  <div class="lab2__head">
+                    <p class="lab2__meta">
+                      {it.statusLabel} · {it.yr} · {it.k}
+                    </p>
+                    <h3>{it.name}</h3>
+                    <p>{it.what}</p>
+                    <p>
+                      <a class="btn btn--text" href={it.href} target="_blank" rel="noopener">
+                        Play it in its own tab <span aria-hidden="true">&rarr;</span>
+                      </a>
+                    </p>
+                  </div>
+                </article>
+              ))
+            }
           </div>
         </div>
       </section>

--- a/src/sections/Playground.astro
+++ b/src/sections/Playground.astro
@@ -134,24 +134,36 @@ const rzShots = [
         note="Vendored three.js r70, served from its original URL"
       />
     </article>
+  </div>
 
+  {
+    /* The newest two invert the section's rule twice over: they are not
+      old, and they do not run inline. Full games want the whole screen,
+      the keyboard and a save file, so they get doors instead of windows.
+      Doors are all text, so their row splits evenly rather than in a
+      frame's favour. */
+  }
+  <div class="labs labs--doors">
     {
-      /* The newest one inverts the section's rule twice: it is not old, and
-        it does not run inline. A full tower defense wants the whole screen,
-        the keyboard and a save file, so it gets a door instead of a window. */
+      playground.items.slice(3).map((it) => (
+        <article class="lab" data-reveal>
+          <div class="lab__head">
+            <span class="lab__date">{it.statusLabel}</span>
+            <h3>
+              {it.name}
+              <span class="era">{it.yr}</span>
+            </h3>
+            <p>{it.what}</p>
+            <p class="stack">{dots(it.k)}</p>
+            <p>
+              <a class="toolbar__link" href={it.href} target="_blank" rel="noopener">
+                Play it in its own tab <span aria-hidden="true">&rarr;</span>
+              </a>
+            </p>
+          </div>
+        </article>
+      ))
     }
-    <article class="lab" data-reveal>
-      <div class="lab__head">
-        <span class="lab__date">{playground.items[3]?.statusLabel}</span>
-        <h3>
-          {playground.items[3]?.name}<span class="era">{playground.items[3]?.yr}</span>
-        </h3>
-        <p>{playground.items[3]?.what}</p>
-        <p>
-          <a class="toolbar__link" href={playground.items[3]?.href}>Play it in its own tab &rarr;</a>
-        </p>
-      </div>
-    </article>
   </div>
 
   {

--- a/src/sections/Playground.astro
+++ b/src/sections/Playground.astro
@@ -134,6 +134,24 @@ const rzShots = [
         note="Vendored three.js r70, served from its original URL"
       />
     </article>
+
+    {
+      /* The newest one inverts the section's rule twice: it is not old, and
+        it does not run inline. A full tower defense wants the whole screen,
+        the keyboard and a save file, so it gets a door instead of a window. */
+    }
+    <article class="lab" data-reveal>
+      <div class="lab__head">
+        <span class="lab__date">{playground.items[3]?.statusLabel}</span>
+        <h3>
+          {playground.items[3]?.name}<span class="era">{playground.items[3]?.yr}</span>
+        </h3>
+        <p>{playground.items[3]?.what}</p>
+        <p>
+          <a class="toolbar__link" href={playground.items[3]?.href}>Play it in its own tab &rarr;</a>
+        </p>
+      </div>
+    </article>
   </div>
 
   {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3124,6 +3124,31 @@ summary,
   }
 }
 
+/* The doors row is all text: there is no frame to feed, so it splits evenly,
+   and it holds as a row long after the demos above have given theirs up. */
+.labs--doors {
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+}
+
+.labs--doors .stack {
+  color: var(--muted);
+  font: 650 0.69rem/1.45 var(--mono);
+}
+
+/* The two descriptions differ in length; the links should not differ in
+   height. The head takes the card's full drop and hands the gap to the
+   space above its link. */
+.labs--doors .lab__head {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.labs--doors .lab__head p:last-child {
+  margin-top: auto;
+  padding-top: 1rem;
+}
+
 /* The break before the game. Two demos, then a rule, then the one thing on the
    page still in someone else's colours - so the rule is the section's heaviest
    and the strip states what changes. It is a grid item, spanning whatever the


### PR DESCRIPTION
## Summary

Two new games join the Playground: Blockhold (a 3D voxel tower defense) and Cubit (2048 in a 3x3x3 cube), both deployed under this domain at /blockhold/ and /cubit/. They do not run inline - full games want the whole screen and a save file - so they render as link cards below the three embedded demos, on both routes.

## Changes

- src/data/content.ts: two new playground items with the shared seven-field shape; section intro reworked to cover them.
- src/sections/Playground.astro: the new cards live in their own equal-column .labs--doors row (the inherited 0.62/1 split exists for the demo frames), show their stack line via dots(k), and open in a new tab as the link text promises.
- src/pages/alternate.astro: the same two cards as lab2 articles, so the shared prose stays accurate on that route.
- src/styles/global.css: .labs--doors grid + stack styling; the link pins to the card bottom so the two buttons share a baseline.

Copy and structure reviewed by a Codex pass (voice fit, /alternate accuracy, a11y on the arrow, unused fields); all findings addressed.

## Output

- npm run build, eslint, prettier, check-mq all pass.
- npm run verify: only the four pre-existing lab-mount failures that also fail on clean master; no new failures.
- Verified in the preview server on both routes: cards render evenly, buttons on one baseline, links open the live games.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015pzwA6a6zbXxQoCpWiiFgF